### PR TITLE
Add test coverage reporting and fix CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - full-refactor
 
 jobs:
   lint-and-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,30 @@ jobs:
       - name: Type check
         run: yarn tsc --noEmit
 
-      - name: Test
-        run: yarn test
+      - name: Test with Coverage
+        run: yarn test:coverage
+
+      - name: Coverage Summary
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            echo "## 📊 Test Coverage Report" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| File | Statements | Branches | Functions | Lines |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|-----------|----------|-----------|-------|" >> $GITHUB_STEP_SUMMARY
+
+            node -e "
+              const data = require('./coverage/coverage-summary.json');
+              for (const [file, metrics] of Object.entries(data)) {
+                const name = file === 'total' ? '**Total**' : file.replace(process.cwd() + '/', '');
+                const stmt = metrics.statements.pct + '%';
+                const branch = metrics.branches.pct + '%';
+                const func = metrics.functions.pct + '%';
+                const lines = metrics.lines.pct + '%';
+                console.log('| ' + name + ' | ' + stmt + ' | ' + branch + ' | ' + func + ' | ' + lines + ' |');
+              }
+            " >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Build
         run: yarn build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Current version in package.json: $CURRENT_VERSION"
 
           # Get published version from npm (if it exists)
-          PUBLISHED_VERSION=$(npm view vite-plugin-native-modules version 2>/dev/null || echo "none")
+          PUBLISHED_VERSION=$(npm view lzma-web version 2>/dev/null || echo "none")
           echo "Published version on npm: $PUBLISHED_VERSION"
 
           # Compare versions

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@eslint/js": "^9.38.0",
     "@types/node": "22.18.0",
+    "@vitest/coverage-v8": "^2.1.8",
     "@vitest/ui": "^2.1.8",
     "eslint": "9.38.0",
     "eslint-config-prettier": "^9.1.0",
@@ -45,6 +46,7 @@
   "scripts": {
     "build": "tsup",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:perf": "node scripts/track-perf.js",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint": "9.38.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "happy-dom": "^20.0.11",
     "prettier": "^3.3.3",
     "tsup": "8.5.0",
     "typescript": "5.9.3",

--- a/src/lzma_main.ts
+++ b/src/lzma_main.ts
@@ -240,9 +240,9 @@ function toDouble(a: LongLit): number {
  * Simple byte array input stream
  */
 class ByteArrayInputStream {
-  private buf: any[]
-  private pos: number
-  private count: number
+  buf: any[]
+  pos: number
+  count: number
 
   constructor(buf: any[]) {
     this.buf = buf

--- a/src/lzma_main.ts
+++ b/src/lzma_main.ts
@@ -304,7 +304,8 @@ function $ByteArrayInputStream(this$static: any, buf: any[]): any {
   this$static.pos = stream.pos
   this$static.count = stream.count
   this$static.read = () => stream.read()
-  this$static.readBytes = (b: any[], o: number, l: number) => stream.readBytes(b, o, l)
+  this$static.readBytes = (b: any[], o: number, l: number) =>
+    stream.readBytes(b, o, l)
   return this$static
 }
 /** ds */

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,0 +1,706 @@
+/**
+ * Comprehensive API tests for lzma-web
+ *
+ * These tests cover the full API surface to ensure behavior is preserved
+ * during refactoring. They test:
+ * - Promise-based API (lzma class from index.ts)
+ * - Callback-based API (lzma_main.ts directly)
+ * - Synchronous API (lzma_main.ts)
+ * - All compression modes (1-9)
+ * - Different input types (string, Uint8Array, Buffer)
+ * - Edge cases (unicode, binary, large data)
+ * - Error handling
+ * - Progress callbacks
+ *
+ * Note: The LZMA export from index.ts uses web workers and is browser-only.
+ * These tests focus on the Node.js-compatible APIs.
+ */
+
+import { describe, test, expect } from 'vitest'
+import lzma from '../src/index.js'
+import {
+  compress as compressMain,
+  decompress as decompressMain,
+} from '../src/lzma_main.js'
+
+type CompressMode = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
+
+// Promisified helpers for callback-based API
+const compressCB = (
+  data: string | Uint8Array,
+  mode: CompressMode,
+): Promise<Uint8Array> => {
+  return new Promise((resolve, reject) => {
+    compressMain(data, mode, (result, error) => {
+      if (error) reject(error)
+      else if (result) resolve(result as Uint8Array)
+      else reject(new Error('Compression returned null'))
+    })
+  })
+}
+
+const decompressCB = (data: Uint8Array): Promise<string | Uint8Array> => {
+  return new Promise((resolve, reject) => {
+    decompressMain(data, (result, error) => {
+      if (error) reject(error)
+      else if (result !== null && result !== undefined) resolve(result)
+      else reject(new Error('Decompression returned null'))
+    })
+  })
+}
+
+describe('Promise-based API (lzma class)', () => {
+  const client = new lzma()
+
+  describe('compress', () => {
+    test('compresses string with default mode', async () => {
+      const input = 'Hello, World!'
+      const compressed = await client.compress(input)
+
+      expect(compressed).toBeInstanceOf(Uint8Array)
+      expect(compressed.length).toBeGreaterThan(0)
+      // LZMA files start with 0x5d (properties byte)
+      expect(compressed[0]).toBe(0x5d)
+    })
+
+    test('compresses string with explicit mode', async () => {
+      const input = 'Hello, World!'
+      const compressed = await client.compress(input, 5)
+
+      expect(compressed).toBeInstanceOf(Uint8Array)
+      expect(compressed.length).toBeGreaterThan(0)
+    })
+
+    test('compresses Uint8Array', async () => {
+      const input = new Uint8Array([72, 101, 108, 108, 111]) // "Hello"
+      const compressed = await client.compress(input)
+
+      expect(compressed).toBeInstanceOf(Uint8Array)
+      expect(compressed.length).toBeGreaterThan(0)
+    })
+
+    test('compression with all modes 1-9', async () => {
+      const input = 'Test data for compression mode testing'
+
+      for (let mode = 1; mode <= 9; mode++) {
+        const compressed = await client.compress(input, mode as CompressMode)
+        expect(compressed).toBeInstanceOf(Uint8Array)
+        expect(compressed.length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('decompress', () => {
+    test('decompresses to original string', async () => {
+      const input = 'Hello, World!'
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+
+      expect(decompressed).toBe(input)
+    })
+
+    test('decompresses binary data to Uint8Array', async () => {
+      // Use binary data with non-printable bytes
+      const input = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe])
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+
+      expect(decompressed).toBeInstanceOf(Uint8Array)
+      expect(decompressed).toEqual(input)
+    })
+  })
+
+  describe('round-trip compression/decompression', () => {
+    test('preserves single character', async () => {
+      const input = 'a'
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+
+      expect(decompressed).toBe(input)
+    })
+
+    test('preserves unicode characters', async () => {
+      const input = '你好世界! 🎉 Ñoño émoji'
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+
+      expect(decompressed).toBe(input)
+    })
+
+    test('preserves multi-byte unicode', async () => {
+      const input = '𝕳𝖊𝖑𝖑𝖔 𝖂𝖔𝖗𝖑𝖉' // Gothic script
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+
+      expect(decompressed).toBe(input)
+    })
+
+    test('preserves newlines and special characters', async () => {
+      const input = 'Line1\nLine2\r\nLine3\tTab'
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+
+      expect(decompressed).toBe(input)
+    })
+
+    test('preserves repeated pattern (highly compressible)', async () => {
+      const input = 'abcdefg'.repeat(1000)
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+
+      expect(decompressed).toBe(input)
+      // Repeated data should compress well
+      expect(compressed.length).toBeLessThan(input.length)
+    })
+
+    test('preserves binary data with null bytes', async () => {
+      const input = new Uint8Array([0x00, 0x00, 0x00, 0x01, 0x02, 0x00])
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+
+      expect(decompressed).toEqual(input)
+    })
+
+    test('preserves all byte values 0-255', async () => {
+      const input = new Uint8Array(256)
+      for (let i = 0; i < 256; i++) {
+        input[i] = i
+      }
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+
+      expect(decompressed).toEqual(input)
+    })
+  })
+
+  describe('cb property (callback access)', () => {
+    test('exposes compress function', () => {
+      expect(typeof client.cb.compress).toBe('function')
+    })
+
+    test('exposes decompress function', () => {
+      expect(typeof client.cb.decompress).toBe('function')
+    })
+
+    test('cb.compress works correctly', async () => {
+      const input = 'test callback'
+      const compressed = await new Promise<Uint8Array>((resolve, reject) => {
+        client.cb.compress(input, 1, (result, error) => {
+          if (error) reject(error)
+          else resolve(result as Uint8Array)
+        })
+      })
+
+      expect(compressed).toBeInstanceOf(Uint8Array)
+      expect(compressed.length).toBeGreaterThan(0)
+    })
+
+    test('cb.decompress works correctly', async () => {
+      const input = 'test callback'
+      const compressed = await client.compress(input)
+      const decompressed = await new Promise<string | Uint8Array>(
+        (resolve, reject) => {
+          client.cb.decompress(compressed, (result, error) => {
+            if (error) reject(error)
+            else if (result) resolve(result)
+            else reject(new Error('null result'))
+          })
+        },
+      )
+
+      expect(decompressed).toBe(input)
+    })
+  })
+})
+
+describe('Callback-based API (lzma_main.ts)', () => {
+  describe('compress', () => {
+    test('compresses string with callback', async () => {
+      const input = 'Hello, World!'
+      const compressed = await compressCB(input, 1)
+
+      expect(compressed).toBeInstanceOf(Uint8Array)
+      expect(compressed.length).toBeGreaterThan(0)
+    })
+
+    test('calls callback asynchronously', () => {
+      return new Promise<void>((resolve) => {
+        let callbackCalled = false
+
+        compressMain('test', 1, (result) => {
+          callbackCalled = true
+          expect(result).toBeInstanceOf(Uint8Array)
+          resolve()
+        })
+
+        // Callback should not be called synchronously
+        expect(callbackCalled).toBe(false)
+      })
+    })
+  })
+
+  describe('decompress', () => {
+    test('decompresses with callback', async () => {
+      const input = 'Hello, World!'
+      const compressed = await compressCB(input, 1)
+      const decompressed = await decompressCB(compressed)
+
+      expect(decompressed).toBe(input)
+    })
+
+    test('calls callback asynchronously', async () => {
+      const compressed = await compressCB('test', 1)
+
+      return new Promise<void>((resolve) => {
+        let callbackCalled = false
+
+        decompressMain(compressed, (result) => {
+          callbackCalled = true
+          expect(result).toBe('test')
+          resolve()
+        })
+
+        // Callback should not be called synchronously
+        expect(callbackCalled).toBe(false)
+      })
+    })
+  })
+
+  describe('progress callbacks', () => {
+    test('compress calls progress callback', async () => {
+      const progressValues: number[] = []
+      const input = 'a'.repeat(10000) // Larger input to trigger progress
+
+      await new Promise<void>((resolve, reject) => {
+        compressMain(
+          input,
+          1,
+          (result, error) => {
+            if (error) reject(error)
+            else resolve()
+          },
+          (progress) => {
+            progressValues.push(progress)
+          },
+        )
+      })
+
+      // Should have at least start (0) and end (1) progress
+      expect(progressValues.length).toBeGreaterThanOrEqual(2)
+      expect(progressValues[0]).toBe(0)
+      expect(progressValues[progressValues.length - 1]).toBe(1)
+    })
+
+    test('decompress calls progress callback', async () => {
+      const progressValues: number[] = []
+      const input = 'a'.repeat(10000)
+      const compressed = await compressCB(input, 1)
+
+      await new Promise<void>((resolve, reject) => {
+        decompressMain(
+          compressed,
+          (result, error) => {
+            if (error) reject(error)
+            else resolve()
+          },
+          (progress) => {
+            progressValues.push(progress)
+          },
+        )
+      })
+
+      // Should have at least start (0) and end (1) progress
+      expect(progressValues.length).toBeGreaterThanOrEqual(2)
+      expect(progressValues[0]).toBe(0)
+      expect(progressValues[progressValues.length - 1]).toBe(1)
+    })
+  })
+})
+
+describe('Synchronous API (lzma_main.ts)', () => {
+  describe('compress (sync mode)', () => {
+    test('returns Uint8Array when called without callbacks', () => {
+      const input = 'Hello, World!'
+      const result = compressMain(input, 1)
+
+      expect(result).toBeInstanceOf(Uint8Array)
+      expect((result as Uint8Array).length).toBeGreaterThan(0)
+    })
+
+    test('compresses different modes synchronously', () => {
+      const input = 'Test data'
+
+      for (let mode = 1; mode <= 9; mode++) {
+        const result = compressMain(input, mode as CompressMode)
+        expect(result).toBeInstanceOf(Uint8Array)
+      }
+    })
+  })
+
+  describe('decompress (sync mode)', () => {
+    test('returns string when called without callbacks', () => {
+      const input = 'Hello, World!'
+      const compressed = compressMain(input, 1) as Uint8Array
+      const result = decompressMain(compressed)
+
+      expect(result).toBe(input)
+    })
+
+    test('returns Uint8Array for binary input', () => {
+      const input = new Uint8Array([0x00, 0x01, 0x02, 0xff])
+      const compressed = compressMain(input, 1) as Uint8Array
+      const result = decompressMain(compressed)
+
+      expect(result).toEqual(input)
+    })
+  })
+
+  describe('round-trip sync', () => {
+    test('preserves string data', () => {
+      const input = 'Synchronous test string'
+      const compressed = compressMain(input, 1) as Uint8Array
+      const decompressed = decompressMain(compressed)
+
+      expect(decompressed).toBe(input)
+    })
+
+    test('preserves binary data', () => {
+      const input = new Uint8Array([1, 2, 3, 4, 5, 255, 254, 253])
+      const compressed = compressMain(input, 1) as Uint8Array
+      const decompressed = decompressMain(compressed)
+
+      expect(decompressed).toEqual(input)
+    })
+  })
+})
+
+describe('Compression modes behavior', () => {
+  const client = new lzma()
+  const testData = 'The quick brown fox jumps over the lazy dog. '.repeat(100)
+
+  test('higher modes produce smaller or equal output for compressible data', async () => {
+    const sizes: number[] = []
+
+    for (let mode = 1; mode <= 9; mode++) {
+      const compressed = await client.compress(testData, mode as CompressMode)
+      sizes.push(compressed.length)
+    }
+
+    // Generally higher modes should produce smaller output
+    // At minimum, highest mode should be <= lowest mode for compressible data
+    expect(sizes[8]).toBeLessThanOrEqual(sizes[0])
+  })
+
+  test('all modes produce valid decompressible output', async () => {
+    for (let mode = 1; mode <= 9; mode++) {
+      const compressed = await client.compress(testData, mode as CompressMode)
+      const decompressed = await client.decompress(compressed)
+      expect(decompressed).toBe(testData)
+    }
+  })
+})
+
+describe('Input type handling', () => {
+  const client = new lzma()
+
+  describe('string input', () => {
+    test('handles ASCII string', async () => {
+      const input = 'Hello World'
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+      expect(decompressed).toBe(input)
+    })
+
+    test('handles UTF-8 string', async () => {
+      const input = 'Héllo Wörld 你好'
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+      expect(decompressed).toBe(input)
+    })
+  })
+
+  describe('Uint8Array input', () => {
+    test('handles Uint8Array with binary data', async () => {
+      // Binary data (non-printable) should return Uint8Array
+      const input = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe])
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+      expect(decompressed).toEqual(input)
+    })
+
+    test('Uint8Array with printable ASCII returns string', async () => {
+      // Printable ASCII in Uint8Array decompresses to string
+      const input = new Uint8Array([65, 66, 67, 68]) // ABCD
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+      // Library converts printable ASCII to string
+      expect(decompressed).toBe('ABCD')
+    })
+  })
+
+  describe('Buffer input (Node.js)', () => {
+    test('handles Buffer for compression', async () => {
+      const input = Buffer.from('Hello World')
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+      // Buffer text content decompresses to string
+      expect(decompressed).toBe('Hello World')
+    })
+
+    test('handles Buffer with binary data', async () => {
+      const input = Buffer.from([0x00, 0x01, 0xff, 0xfe])
+      const compressed = await client.compress(input)
+      const decompressed = await client.decompress(compressed)
+      expect(decompressed).toEqual(new Uint8Array(input))
+    })
+  })
+})
+
+describe('Edge cases', () => {
+  const client = new lzma()
+
+  test('handles very long repeated string', async () => {
+    const input = 'x'.repeat(100000)
+    const compressed = await client.compress(input, 1)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+    // Highly repetitive data should compress very well
+    expect(compressed.length).toBeLessThan(input.length / 10)
+  })
+
+  test('handles string with only whitespace', async () => {
+    const input = '   \t\n\r   '
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('handles string with null characters', async () => {
+    const input = 'hello\x00world\x00test'
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('handles very short string', async () => {
+    const input = 'ab'
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('handles JSON string', async () => {
+    const input = JSON.stringify({ key: 'value', number: 42, array: [1, 2, 3] })
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+    expect(JSON.parse(decompressed as string)).toEqual(JSON.parse(input))
+  })
+
+  test('handles base64 encoded data', async () => {
+    const input = Buffer.from('Hello World').toString('base64')
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+})
+
+describe('Error handling', () => {
+  const client = new lzma()
+
+  test('decompress rejects on invalid data', async () => {
+    const invalidData = new Uint8Array([1, 2, 3, 4, 5])
+
+    await expect(client.decompress(invalidData)).rejects.toThrow()
+  })
+
+  test('decompress rejects on corrupted header', async () => {
+    const input = 'Hello World'
+    const compressed = await client.compress(input)
+    // Corrupt the header
+    const corrupted = new Uint8Array(compressed)
+    corrupted[0] = 0xff
+
+    await expect(client.decompress(corrupted)).rejects.toThrow()
+  })
+
+  test('sync decompress throws on invalid data', () => {
+    expect(() => {
+      decompressMain(new Uint8Array([1, 2, 3, 4, 5]))
+    }).toThrow()
+  })
+
+  test('callback API returns error for invalid data', () => {
+    return new Promise<void>((resolve) => {
+      decompressMain(new Uint8Array([1, 2, 3]), (result, error) => {
+        expect(error).toBeDefined()
+        expect(result).toBeNull()
+        resolve()
+      })
+    })
+  })
+})
+
+describe('LZMA format compliance', () => {
+  const client = new lzma()
+
+  test('compressed output starts with LZMA header byte', async () => {
+    const compressed = await client.compress('test')
+    // LZMA files start with 0x5d (properties byte for lc=3, lp=0, pb=2)
+    expect(compressed[0]).toBe(0x5d)
+  })
+
+  test('compressed output contains dictionary size', async () => {
+    const compressed = await client.compress('test')
+    // Bytes 1-4 contain dictionary size (little-endian)
+    const dictSize =
+      compressed[1] |
+      (compressed[2] << 8) |
+      (compressed[3] << 16) |
+      (compressed[4] << 24)
+    expect(dictSize).toBeGreaterThan(0)
+  })
+
+  test('compressed output contains uncompressed size', async () => {
+    const input = 'Hello'
+    const compressed = await client.compress(input)
+    // Bytes 5-12 contain uncompressed size (little-endian, 8 bytes)
+    const sizeLow =
+      compressed[5] |
+      (compressed[6] << 8) |
+      (compressed[7] << 16) |
+      (compressed[8] << 24)
+    // For small inputs, the low bytes should match the input length
+    expect(sizeLow).toBe(input.length)
+  })
+})
+
+describe('Cross-mode compatibility', () => {
+  test('data compressed with mode 1 decompresses correctly', async () => {
+    const input = 'Test data for cross-mode compatibility'
+    const compressed = compressMain(input, 1) as Uint8Array
+    const decompressed = decompressMain(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('data compressed with mode 9 decompresses correctly', async () => {
+    const input = 'Test data for cross-mode compatibility'
+    const compressed = compressMain(input, 9) as Uint8Array
+    const decompressed = decompressMain(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('sync compressed data can be async decompressed', async () => {
+    const client = new lzma()
+    const input = 'Mixed mode test'
+    const compressed = compressMain(input, 5) as Uint8Array
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('async compressed data can be sync decompressed', async () => {
+    const client = new lzma()
+    const input = 'Mixed mode test'
+    const compressed = await client.compress(input, 5)
+    const decompressed = decompressMain(compressed)
+    expect(decompressed).toBe(input)
+  })
+})
+
+describe('Default parameter values', () => {
+  test('lzma.compress uses mode 9 by default', async () => {
+    const client = new lzma()
+    const input = 'Test with default mode'
+
+    const compressedDefault = await client.compress(input)
+    const compressedMode9 = await client.compress(input, 9)
+
+    // Same mode should produce identical output
+    expect(compressedDefault).toEqual(compressedMode9)
+  })
+})
+
+describe('Compression determinism', () => {
+  const client = new lzma()
+
+  test('same input produces same output', async () => {
+    const input = 'Deterministic compression test'
+
+    const compressed1 = await client.compress(input, 5)
+    const compressed2 = await client.compress(input, 5)
+
+    expect(compressed1).toEqual(compressed2)
+  })
+
+  test('sync and async produce same output', async () => {
+    const input = 'Sync vs async test'
+
+    const syncResult = compressMain(input, 5) as Uint8Array
+    const asyncResult = await client.compress(input, 5)
+
+    expect(syncResult).toEqual(asyncResult)
+  })
+})
+
+describe('Large data handling', () => {
+  const client = new lzma()
+
+  test('handles 1MB of text data', async () => {
+    const input = 'Lorem ipsum dolor sit amet. '.repeat(40000) // ~1MB
+    const compressed = await client.compress(input, 1)
+    const decompressed = await client.decompress(compressed)
+
+    expect(decompressed).toBe(input)
+  }, 30000) // 30 second timeout
+
+  test('handles 1MB of random-ish binary data', async () => {
+    const input = new Uint8Array(1024 * 1024)
+    for (let i = 0; i < input.length; i++) {
+      input[i] = (i * 7 + 13) % 256 // Pseudo-random but deterministic
+    }
+
+    const compressed = await client.compress(input, 1)
+    const decompressed = await client.decompress(compressed)
+
+    expect(decompressed).toEqual(input)
+  }, 30000)
+})
+
+describe('Unicode handling', () => {
+  const client = new lzma()
+
+  test('handles CJK characters', async () => {
+    const input = '中文测试 日本語テスト 한국어 테스트'
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('handles Arabic and Hebrew (RTL)', async () => {
+    const input = 'مرحبا بالعالم שלום עולם'
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('handles emoji', async () => {
+    const input = '😀🎉🚀💻🌍🎨🎵🍕'
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('handles combining characters', async () => {
+    const input = 'e\u0301' // é as e + combining acute accent
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+
+  test('handles zero-width characters', async () => {
+    const input = 'a\u200Bb\u200Cc' // zero-width space and non-joiner
+    const compressed = await client.compress(input)
+    const decompressed = await client.decompress(compressed)
+    expect(decompressed).toBe(input)
+  })
+})

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -1,0 +1,630 @@
+/**
+ * Browser environment tests for lzma-web
+ *
+ * These tests run in a simulated browser environment (happy-dom) and test
+ * the worker-based API from lzma.ts. Since happy-dom doesn't fully support
+ * Web Workers, we mock the Worker to simulate the worker's behavior.
+ *
+ * @vitest-environment happy-dom
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { compress, decompress } from '../src/lzma_main.js'
+
+// Mock Worker class that simulates the actual worker behavior
+class MockWorker {
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((e: ErrorEvent) => void) | null = null
+
+  postMessage(data: {
+    action: number
+    cbn: number
+    data: string | Uint8Array | ArrayBuffer
+    mode: number | false
+  }) {
+    // Simulate async worker behavior
+    setTimeout(() => {
+      try {
+        if (data.action === 1) {
+          // Compress
+          compress(data.data, data.mode as 1, (result, error) => {
+            this.onmessage?.({
+              data: {
+                action: 1,
+                cbn: data.cbn,
+                result: result,
+                error: error,
+              },
+            } as MessageEvent)
+          })
+        } else if (data.action === 2) {
+          // Decompress
+          decompress(data.data as Uint8Array, (result, error) => {
+            this.onmessage?.({
+              data: {
+                action: 2,
+                cbn: data.cbn,
+                result: result,
+                error: error,
+              },
+            } as MessageEvent)
+          })
+        }
+      } catch (err) {
+        this.onerror?.({
+          message: (err as Error).message,
+          filename: 'worker.js',
+          lineno: 1,
+        } as ErrorEvent)
+      }
+    }, 0)
+  }
+
+  terminate() {
+    // No-op for mock
+  }
+}
+
+// Store original Worker
+const OriginalWorker = globalThis.Worker
+
+describe('Worker-based API (lzma.ts)', () => {
+  beforeEach(() => {
+    // Mock the Worker globally before importing lzma.ts
+    vi.stubGlobal('Worker', MockWorker)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('mock worker is set up correctly', () => {
+    expect(globalThis.Worker).toBe(MockWorker)
+  })
+
+  // Since lzma.ts creates the worker at import time, we need to dynamically import it
+  test('LZMA.compress works through worker', async () => {
+    // Reset module cache and reimport with mocked Worker
+    vi.resetModules()
+    const { LZMA } = await import('../src/lzma.js')
+
+    const input = 'Hello, Worker World!'
+
+    const result = await new Promise<Uint8Array>((resolve, reject) => {
+      LZMA.compress(input, 1, (result, error) => {
+        if (error) reject(error)
+        else if (result) resolve(result)
+        else reject(new Error('null result'))
+      })
+    })
+
+    expect(result).toBeInstanceOf(Uint8Array)
+    expect(result.length).toBeGreaterThan(0)
+    expect(result[0]).toBe(0x5d) // LZMA header
+  })
+
+  test('LZMA.decompress works through worker', async () => {
+    vi.resetModules()
+    const { LZMA } = await import('../src/lzma.js')
+
+    const input = 'Hello, Worker World!'
+
+    // First compress
+    const compressed = await new Promise<Uint8Array>((resolve, reject) => {
+      LZMA.compress(input, 1, (result, error) => {
+        if (error) reject(error)
+        else if (result) resolve(result)
+        else reject(new Error('null result'))
+      })
+    })
+
+    // Then decompress
+    const decompressed = await new Promise<string | Uint8Array>(
+      (resolve, reject) => {
+        LZMA.decompress(compressed, (result, error) => {
+          if (error) reject(error)
+          else if (result) resolve(result)
+          else reject(new Error('null result'))
+        })
+      },
+    )
+
+    expect(decompressed).toBe(input)
+  })
+
+  test('LZMA.compress with progress callback', async () => {
+    vi.resetModules()
+
+    // Create a mock that also sends progress events
+    class MockWorkerWithProgress extends MockWorker {
+      postMessage(data: {
+        action: number
+        cbn: number
+        data: string | Uint8Array | ArrayBuffer
+        mode: number | false
+      }) {
+        setTimeout(() => {
+          // Send progress updates
+          this.onmessage?.({
+            data: {
+              action: 3, // action_progress
+              cbn: data.cbn,
+              result: 0,
+            },
+          } as MessageEvent)
+
+          this.onmessage?.({
+            data: {
+              action: 3,
+              cbn: data.cbn,
+              result: 0.5,
+            },
+          } as MessageEvent)
+
+          this.onmessage?.({
+            data: {
+              action: 3,
+              cbn: data.cbn,
+              result: 1,
+            },
+          } as MessageEvent)
+
+          // Then send the actual result
+          if (data.action === 1) {
+            compress(data.data, data.mode as 1, (result, error) => {
+              this.onmessage?.({
+                data: {
+                  action: 1,
+                  cbn: data.cbn,
+                  result: result,
+                  error: error,
+                },
+              } as MessageEvent)
+            })
+          }
+        }, 0)
+      }
+    }
+
+    vi.stubGlobal('Worker', MockWorkerWithProgress)
+    const { LZMA } = await import('../src/lzma.js')
+
+    const progressValues: number[] = []
+    const input = 'Test with progress'
+
+    await new Promise<void>((resolve, reject) => {
+      LZMA.compress(
+        input,
+        1,
+        (result, error) => {
+          if (error) reject(error)
+          else resolve()
+        },
+        (progress) => {
+          progressValues.push(progress)
+        },
+      )
+    })
+
+    expect(progressValues).toContain(0)
+    expect(progressValues).toContain(0.5)
+    expect(progressValues).toContain(1)
+  })
+
+  test('LZMA.worker() returns the worker instance', async () => {
+    vi.resetModules()
+    const { LZMA } = await import('../src/lzma.js')
+
+    const worker = LZMA.worker()
+    expect(worker).toBeInstanceOf(MockWorker)
+  })
+
+  test('worker error handling', async () => {
+    vi.resetModules()
+
+    // Create a mock worker that throws an error
+    class ErrorWorker {
+      onmessage: ((e: MessageEvent) => void) | null = null
+      onerror: ((e: ErrorEvent) => void) | null = null
+
+      postMessage() {
+        setTimeout(() => {
+          this.onerror?.({
+            message: 'Worker error',
+            filename: 'worker.js',
+            lineno: 1,
+          } as ErrorEvent)
+        }, 0)
+      }
+
+      terminate() {}
+    }
+
+    vi.stubGlobal('Worker', ErrorWorker)
+    const { LZMA } = await import('../src/lzma.js')
+
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        LZMA.compress('test', 1, (result, error) => {
+          if (error) reject(error)
+          else resolve()
+        })
+      }),
+    ).rejects.toThrow('Worker error')
+  })
+
+  test('handles multiple concurrent operations', async () => {
+    vi.resetModules()
+    vi.stubGlobal('Worker', MockWorker)
+    const { LZMA } = await import('../src/lzma.js')
+
+    const inputs = ['First', 'Second', 'Third']
+    const promises = inputs.map(
+      (input) =>
+        new Promise<{ input: string; result: string | Uint8Array }>(
+          (resolve, reject) => {
+            LZMA.compress(input, 1, (compressed, error) => {
+              if (error) return reject(error)
+              LZMA.decompress(compressed!, (result, error) => {
+                if (error) reject(error)
+                else resolve({ input, result: result! })
+              })
+            })
+          },
+        ),
+    )
+
+    const results = await Promise.all(promises)
+
+    results.forEach(({ input, result }) => {
+      expect(result).toBe(input)
+    })
+  })
+})
+
+describe('Worker message handling edge cases', () => {
+  beforeEach(() => {
+    vi.stubGlobal('Worker', MockWorker)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('ignores messages for unknown callback numbers', async () => {
+    vi.resetModules()
+
+    class MockWorkerWithExtraMessages extends MockWorker {
+      postMessage(data: {
+        action: number
+        cbn: number
+        data: string | Uint8Array | ArrayBuffer
+        mode: number | false
+      }) {
+        setTimeout(() => {
+          // Send a message with unknown cbn first
+          this.onmessage?.({
+            data: {
+              action: 1,
+              cbn: 99999999, // Unknown callback number
+              result: new Uint8Array([1, 2, 3]),
+            },
+          } as MessageEvent)
+
+          // Then send the real result
+          if (data.action === 1) {
+            compress(data.data, data.mode as 1, (result, error) => {
+              this.onmessage?.({
+                data: {
+                  action: 1,
+                  cbn: data.cbn,
+                  result: result,
+                  error: error,
+                },
+              } as MessageEvent)
+            })
+          }
+        }, 0)
+      }
+    }
+
+    vi.stubGlobal('Worker', MockWorkerWithExtraMessages)
+    const { LZMA } = await import('../src/lzma.js')
+
+    // Should still work despite the extra message
+    const result = await new Promise<Uint8Array>((resolve, reject) => {
+      LZMA.compress('test', 1, (result, error) => {
+        if (error) reject(error)
+        else if (result) resolve(result)
+        else reject(new Error('null result'))
+      })
+    })
+
+    expect(result).toBeInstanceOf(Uint8Array)
+  })
+
+  test('progress callback is optional', async () => {
+    vi.resetModules()
+
+    class MockWorkerWithProgress extends MockWorker {
+      postMessage(data: {
+        action: number
+        cbn: number
+        data: string | Uint8Array | ArrayBuffer
+        mode: number | false
+      }) {
+        setTimeout(() => {
+          // Send progress even though no callback is registered
+          this.onmessage?.({
+            data: {
+              action: 3,
+              cbn: data.cbn,
+              result: 0.5,
+            },
+          } as MessageEvent)
+
+          if (data.action === 1) {
+            compress(data.data, data.mode as 1, (result, error) => {
+              this.onmessage?.({
+                data: {
+                  action: 1,
+                  cbn: data.cbn,
+                  result: result,
+                  error: error,
+                },
+              } as MessageEvent)
+            })
+          }
+        }, 0)
+      }
+    }
+
+    vi.stubGlobal('Worker', MockWorkerWithProgress)
+    const { LZMA } = await import('../src/lzma.js')
+
+    // Call without progress callback - should not throw
+    const result = await new Promise<Uint8Array>((resolve, reject) => {
+      LZMA.compress('test', 1, (result, error) => {
+        if (error) reject(error)
+        else if (result) resolve(result)
+        else reject(new Error('null result'))
+      })
+      // No progress callback passed
+    })
+
+    expect(result).toBeInstanceOf(Uint8Array)
+  })
+
+  test('callbacks are cleaned up after completion', async () => {
+    vi.resetModules()
+    vi.stubGlobal('Worker', MockWorker)
+    const { LZMA } = await import('../src/lzma.js')
+
+    // Run a compression
+    await new Promise<void>((resolve, reject) => {
+      LZMA.compress('test', 1, (result, error) => {
+        if (error) reject(error)
+        else resolve()
+      })
+    })
+
+    // The callback should be cleaned up - hard to verify directly
+    // but running multiple operations should work without memory issues
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>((resolve, reject) => {
+        LZMA.compress(`test ${i}`, 1, (result, error) => {
+          if (error) reject(error)
+          else resolve()
+        })
+      })
+    }
+  })
+})
+
+describe('Worker.ts message handler', () => {
+  test('worker handles compress action', async () => {
+    // Test the worker.ts message handler directly
+    const messageHandler = vi.fn()
+
+    // Simulate what the worker does
+    const action_compress = 1
+    const testData = {
+      action: action_compress,
+      data: 'test',
+      mode: 1,
+      cbn: 12345,
+    }
+
+    // The worker calls compress with a callback number
+    const result = await new Promise<Uint8Array>((resolve, reject) => {
+      compress(testData.data, testData.mode as 1, (result, error) => {
+        if (error) reject(error)
+        else resolve(result as Uint8Array)
+      })
+    })
+
+    expect(result).toBeInstanceOf(Uint8Array)
+  })
+
+  test('worker handles decompress action', async () => {
+    const action_decompress = 2
+
+    // First compress some data
+    const compressed = await new Promise<Uint8Array>((resolve, reject) => {
+      compress('test data', 1, (result, error) => {
+        if (error) reject(error)
+        else resolve(result as Uint8Array)
+      })
+    })
+
+    const testData = {
+      action: action_decompress,
+      data: compressed,
+      cbn: 12345,
+    }
+
+    // Decompress
+    const result = await new Promise<string | Uint8Array>((resolve, reject) => {
+      decompress(testData.data, (result, error) => {
+        if (error) reject(error)
+        else resolve(result!)
+      })
+    })
+
+    expect(result).toBe('test data')
+  })
+})
+
+describe('Worker.ts module direct testing', () => {
+  let capturedHandler: ((e: MessageEvent) => void) | null = null
+  let originalAddEventListener: typeof addEventListener
+
+  beforeEach(() => {
+    // Capture the message handler when worker.ts is imported
+    originalAddEventListener = globalThis.addEventListener
+    vi.stubGlobal(
+      'addEventListener',
+      (type: string, handler: (e: MessageEvent) => void) => {
+        if (type === 'message') {
+          capturedHandler = handler
+        }
+      },
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    capturedHandler = null
+  })
+
+  test('worker.ts registers message handler', async () => {
+    vi.resetModules()
+    await import('../src/worker.js')
+
+    expect(capturedHandler).not.toBeNull()
+    expect(typeof capturedHandler).toBe('function')
+  })
+
+  test('worker.ts handles compress action via message', async () => {
+    vi.resetModules()
+
+    // Mock postMessage to capture the result
+    const postedMessages: any[] = []
+    vi.stubGlobal('postMessage', (msg: any) => {
+      postedMessages.push(msg)
+    })
+
+    await import('../src/worker.js')
+
+    expect(capturedHandler).not.toBeNull()
+
+    // Simulate a compress message
+    const testCbn = 12345
+    capturedHandler!({
+      data: {
+        action: 1, // action_compress
+        data: 'Hello Worker',
+        mode: 1,
+        cbn: testCbn,
+      },
+    } as MessageEvent)
+
+    // Wait for async compression to complete
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // Check that postMessage was called with the result
+    const resultMessage = postedMessages.find(
+      (m) => m.action === 1 && m.cbn === testCbn,
+    )
+    expect(resultMessage).toBeDefined()
+    expect(resultMessage.result).toBeInstanceOf(Uint8Array)
+  })
+
+  test('worker.ts handles decompress action via message', async () => {
+    vi.resetModules()
+
+    // First compress some data
+    const compressed = await new Promise<Uint8Array>((resolve, reject) => {
+      compress('Hello Worker', 1, (result, error) => {
+        if (error) reject(error)
+        else resolve(result as Uint8Array)
+      })
+    })
+
+    // Mock postMessage
+    const postedMessages: any[] = []
+    vi.stubGlobal('postMessage', (msg: any) => {
+      postedMessages.push(msg)
+    })
+
+    await import('../src/worker.js')
+
+    expect(capturedHandler).not.toBeNull()
+
+    // Simulate a decompress message
+    const testCbn = 54321
+    capturedHandler!({
+      data: {
+        action: 2, // action_decompress
+        data: compressed,
+        cbn: testCbn,
+      },
+    } as MessageEvent)
+
+    // Wait for async decompression to complete
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // Check that postMessage was called with the result
+    const resultMessage = postedMessages.find(
+      (m) => m.action === 2 && m.cbn === testCbn,
+    )
+    expect(resultMessage).toBeDefined()
+    expect(resultMessage.result).toBe('Hello Worker')
+  })
+
+  test('worker.ts ignores invalid action', async () => {
+    vi.resetModules()
+
+    const postedMessages: any[] = []
+    vi.stubGlobal('postMessage', (msg: any) => {
+      postedMessages.push(msg)
+    })
+
+    await import('../src/worker.js')
+
+    // Simulate an invalid action
+    capturedHandler!({
+      data: {
+        action: 999, // Invalid action
+        data: 'test',
+        cbn: 11111,
+      },
+    } as MessageEvent)
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // No message should be posted for invalid action
+    expect(postedMessages.length).toBe(0)
+  })
+
+  test('worker.ts handles null/undefined message data', async () => {
+    vi.resetModules()
+
+    const postedMessages: any[] = []
+    vi.stubGlobal('postMessage', (msg: any) => {
+      postedMessages.push(msg)
+    })
+
+    await import('../src/worker.js')
+
+    // These should not throw
+    capturedHandler!({ data: null } as MessageEvent)
+    capturedHandler!({ data: undefined } as MessageEvent)
+    capturedHandler!({} as MessageEvent)
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // No messages should be posted
+    expect(postedMessages.length).toBe(0)
+  })
+})

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -65,9 +65,6 @@ class MockWorker {
   }
 }
 
-// Store original Worker
-const OriginalWorker = globalThis.Worker
-
 describe('Worker-based API (lzma.ts)', () => {
   beforeEach(() => {
     // Mock the Worker globally before importing lzma.ts
@@ -423,9 +420,6 @@ describe('Worker message handling edge cases', () => {
 
 describe('Worker.ts message handler', () => {
   test('worker handles compress action', async () => {
-    // Test the worker.ts message handler directly
-    const messageHandler = vi.fn()
-
     // Simulate what the worker does
     const action_compress = 1
     const testData = {
@@ -477,11 +471,9 @@ describe('Worker.ts message handler', () => {
 
 describe('Worker.ts module direct testing', () => {
   let capturedHandler: ((e: MessageEvent) => void) | null = null
-  let originalAddEventListener: typeof addEventListener
 
   beforeEach(() => {
     // Capture the message handler when worker.ts is imported
-    originalAddEventListener = globalThis.addEventListener
     vi.stubGlobal(
       'addEventListener',
       (type: string, handler: (e: MessageEvent) => void) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,5 +21,11 @@ export default defineConfig({
     outputFile: {
       json: './test-results.json',
     },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'json-summary', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/worker.ts'],
+    },
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,7 +25,6 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],
       include: ['src/**/*.ts'],
-      exclude: ['src/worker.ts'],
     },
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -830,6 +830,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^20.0.0":
+  version: 20.19.27
+  resolution: "@types/node@npm:20.19.27"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/7599c24d80465c1aa6e29b53581fc20ad8862ff33e6eef31d05c1c706868476ee57319c89b802ea972dd4d64ce86d18020aa5344f851fb59b730ea509a63300f
+  languageName: node
+  linkType: hard
+
+"@types/whatwg-mimetype@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@types/whatwg-mimetype@npm:3.0.2"
+  checksum: 10c0/dad39d1e4abe760a0a963c84bbdbd26b1df0eb68aff83bdf6ecbb50ad781ead777f6906d19a87007790b750f7500a12e5624d31fc6a1529d14bd19b5c3a316d1
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:8.46.2":
   version: 8.46.2
   resolution: "@typescript-eslint/eslint-plugin@npm:8.46.2"
@@ -2036,6 +2052,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"happy-dom@npm:^20.0.11":
+  version: 20.0.11
+  resolution: "happy-dom@npm:20.0.11"
+  dependencies:
+    "@types/node": "npm:^20.0.0"
+    "@types/whatwg-mimetype": "npm:^3.0.2"
+    whatwg-mimetype: "npm:^3.0.0"
+  checksum: 10c0/818c44630fdb73258d12932646ab966190953820e5d8d032bc6ef51d00d6400097a91d28e212483216898c87d645e1728ae577951256ad989f75da6f9c1f8792
+  languageName: node
+  linkType: hard
+
 "has-flag@npm:^4.0.0":
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
@@ -2356,6 +2383,7 @@ __metadata:
     eslint: "npm:9.38.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-prettier: "npm:^5.2.1"
+    happy-dom: "npm:^20.0.11"
     prettier: "npm:^3.3.3"
     tsup: "npm:8.5.0"
     typescript: "npm:5.9.3"
@@ -3629,6 +3657,13 @@ __metadata:
   version: 4.0.2
   resolution: "webidl-conversions@npm:4.0.2"
   checksum: 10c0/def5c5ac3479286dffcb604547628b2e6b46c5c5b8a8cfaa8c71dc3bafc85859bde5fbe89467ff861f571ab38987cf6ab3d6e7c80b39b999e50e803c12f3164f
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "whatwg-mimetype@npm:3.0.0"
+  checksum: 10c0/323895a1cda29a5fb0b9ca82831d2c316309fede0365047c4c323073e3239067a304a09a1f4b123b9532641ab604203f33a1403b5ca6a62ef405bcd7a204080f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,58 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@ampproject/remapping@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@ampproject/remapping@npm:2.3.0"
+  dependencies:
+    "@jridgewell/gen-mapping": "npm:^0.3.5"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10c0/81d63cca5443e0f0c72ae18b544cc28c7c0ec2cea46e7cb888bb0e0f411a1191d0d6b7af798d54e30777d8d1488b2ec0732aac2be342d3d7d3ffd271c6f489ed
+  languageName: node
+  linkType: hard
+
+"@babel/helper-string-parser@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-string-parser@npm:7.27.1"
+  checksum: 10c0/8bda3448e07b5583727c103560bcf9c4c24b3c1051a4c516d4050ef69df37bb9a4734a585fe12725b8c2763de0a265aa1e909b485a4e3270b7cfd3e4dbe4b602
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.28.5":
+  version: 7.28.5
+  resolution: "@babel/helper-validator-identifier@npm:7.28.5"
+  checksum: 10c0/42aaebed91f739a41f3d80b72752d1f95fd7c72394e8e4bd7cdd88817e0774d80a432451bcba17c2c642c257c483bf1d409dd4548883429ea9493a3bc4ab0847
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.25.4":
+  version: 7.28.5
+  resolution: "@babel/parser@npm:7.28.5"
+  dependencies:
+    "@babel/types": "npm:^7.28.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/5bbe48bf2c79594ac02b490a41ffde7ef5aa22a9a88ad6bcc78432a6ba8a9d638d531d868bd1f104633f1f6bba9905746e15185b8276a3756c42b765d131b1ef
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.25.4, @babel/types@npm:^7.28.5":
+  version: 7.28.5
+  resolution: "@babel/types@npm:7.28.5"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.27.1"
+    "@babel/helper-validator-identifier": "npm:^7.28.5"
+  checksum: 10c0/a5a483d2100befbf125793640dec26b90b95fd233a94c19573325898a5ce1e52cdfa96e495c7dcc31b5eca5b66ce3e6d4a0f5a4a62daec271455959f208ab08a
+  languageName: node
+  linkType: hard
+
+"@bcoe/v8-coverage@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@bcoe/v8-coverage@npm:0.2.3"
+  checksum: 10c0/6b80ae4cb3db53f486da2dc63b6e190a74c8c3cca16bb2733f234a0b6a9382b09b146488ae08e2b22cf00f6c83e20f3e040a2f7894f05c045c946d6a090b1d52
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/aix-ppc64@npm:0.21.5"
@@ -490,7 +542,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.2":
+"@istanbuljs/schema@npm:^0.1.2":
+  version: 0.1.3
+  resolution: "@istanbuljs/schema@npm:0.1.3"
+  checksum: 10c0/61c5286771676c9ca3eb2bd8a7310a9c063fb6e0e9712225c8471c582d157392c88f5353581c8c9adbe0dff98892317d2fdfc56c3499aa42e0194405206a963a
+  languageName: node
+  linkType: hard
+
+"@jridgewell/gen-mapping@npm:^0.3.2, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.13
   resolution: "@jridgewell/gen-mapping@npm:0.3.13"
   dependencies:
@@ -514,7 +573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.24":
+"@jridgewell/trace-mapping@npm:^0.3.23, @jridgewell/trace-mapping@npm:^0.3.24":
   version: 0.3.31
   resolution: "@jridgewell/trace-mapping@npm:0.3.31"
   dependencies:
@@ -908,6 +967,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/coverage-v8@npm:^2.1.8":
+  version: 2.1.9
+  resolution: "@vitest/coverage-v8@npm:2.1.9"
+  dependencies:
+    "@ampproject/remapping": "npm:^2.3.0"
+    "@bcoe/v8-coverage": "npm:^0.2.3"
+    debug: "npm:^4.3.7"
+    istanbul-lib-coverage: "npm:^3.2.2"
+    istanbul-lib-report: "npm:^3.0.1"
+    istanbul-lib-source-maps: "npm:^5.0.6"
+    istanbul-reports: "npm:^3.1.7"
+    magic-string: "npm:^0.30.12"
+    magicast: "npm:^0.3.5"
+    std-env: "npm:^3.8.0"
+    test-exclude: "npm:^7.0.1"
+    tinyrainbow: "npm:^1.2.0"
+  peerDependencies:
+    "@vitest/browser": 2.1.9
+    vitest: 2.1.9
+  peerDependenciesMeta:
+    "@vitest/browser":
+      optional: true
+  checksum: 10c0/ccf5871954a630453af9393e84ff40a0f8a4515e988ea32c7ebac5db7c79f17535a12c1c2567cbb78ea01a1eb99abdde94e297f6b6ccd5f7f7fc9b8b01c5963c
+  languageName: node
+  linkType: hard
+
 "@vitest/expect@npm:2.1.9":
   version: 2.1.9
   resolution: "@vitest/expect@npm:2.1.9"
@@ -1294,7 +1379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0":
+"debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -1914,6 +1999,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^10.4.1":
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^3.1.2"
+    minimatch: "npm:^9.0.4"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^1.11.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/100705eddbde6323e7b35e1d1ac28bcb58322095bd8e63a7d0bef1a2cdafe0d0f7922a981b2b48369a4f8c1b077be5c171804534c3509dfe950dde15fbe6d828
+  languageName: node
+  linkType: hard
+
 "globals@npm:^14.0.0":
   version: 14.0.0
   resolution: "globals@npm:14.0.0"
@@ -1939,6 +2040,13 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
   languageName: node
   linkType: hard
 
@@ -2057,6 +2165,45 @@ __metadata:
   version: 3.1.1
   resolution: "isexe@npm:3.1.1"
   checksum: 10c0/9ec257654093443eb0a528a9c8cbba9c0ca7616ccb40abd6dde7202734d96bb86e4ac0d764f0f8cd965856aacbff2f4ce23e730dc19dfb41e3b0d865ca6fdcc7
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 10c0/6c7ff2106769e5f592ded1fb418f9f73b4411fd5a084387a5410538332b6567cd1763ff6b6cadca9b9eb2c443cce2f7ea7d7f1b8d315f9ce58539793b1e0922b
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: "npm:^3.0.0"
+    make-dir: "npm:^4.0.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10c0/84323afb14392de8b6a5714bd7e9af845cfbd56cfe71ed276cda2f5f1201aea673c7111901227ee33e68e4364e288d73861eb2ed48f6679d1e69a43b6d9b3ba7
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-source-maps@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "istanbul-lib-source-maps@npm:5.0.6"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.23"
+    debug: "npm:^4.1.1"
+    istanbul-lib-coverage: "npm:^3.0.0"
+  checksum: 10c0/ffe75d70b303a3621ee4671554f306e0831b16f39ab7f4ab52e54d356a5d33e534d97563e318f1333a6aae1d42f91ec49c76b6cd3f3fb378addcb5c81da0255f
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.1.7":
+  version: 3.2.0
+  resolution: "istanbul-reports@npm:3.2.0"
+  dependencies:
+    html-escaper: "npm:^2.0.0"
+    istanbul-lib-report: "npm:^3.0.0"
+  checksum: 10c0/d596317cfd9c22e1394f22a8d8ba0303d2074fe2e971887b32d870e4b33f8464b10f8ccbe6847808f7db485f084eba09e6c2ed706b3a978e4b52f07085b8f9bc
   languageName: node
   linkType: hard
 
@@ -2204,6 +2351,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.38.0"
     "@types/node": "npm:22.18.0"
+    "@vitest/coverage-v8": "npm:^2.1.8"
     "@vitest/ui": "npm:^2.1.8"
     eslint: "npm:9.38.0"
     eslint-config-prettier: "npm:^9.1.0"
@@ -2223,6 +2371,26 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.5"
   checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
+  languageName: node
+  linkType: hard
+
+"magicast@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "magicast@npm:0.3.5"
+  dependencies:
+    "@babel/parser": "npm:^7.25.4"
+    "@babel/types": "npm:^7.25.4"
+    source-map-js: "npm:^1.2.0"
+  checksum: 10c0/a6cacc0a848af84f03e3f5bda7b0de75e4d0aa9ddce5517fd23ed0f31b5ddd51b2d0ff0b7e09b51f7de0f4053c7a1107117edda6b0732dca3e9e39e6c5a68c64
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: "npm:^7.5.3"
+  checksum: 10c0/69b98a6c0b8e5c4fe9acb61608a9fbcfca1756d910f51e5dbe7a9e5cfb74fca9b8a0c8a0ffdf1294a740826c1ab4871d5bf3f62f72a3049e5eac6541ddffed68
   languageName: node
   linkType: hard
 
@@ -2833,7 +3001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.6.0":
+"semver@npm:^7.5.3, semver@npm:^7.6.0":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
   bin:
@@ -2911,7 +3079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.2.0, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
@@ -3043,6 +3211,17 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10c0/0dad0596a61586180981133b20c32cfd93c5863c5b7140d646714e6ea8ec84583b879e5dc3928a4d683be6e6109ad7ea3de1cf71986d5194f81b3a016c8858c9
+  languageName: node
+  linkType: hard
+
+"test-exclude@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "test-exclude@npm:7.0.1"
+  dependencies:
+    "@istanbuljs/schema": "npm:^0.1.2"
+    glob: "npm:^10.4.1"
+    minimatch: "npm:^9.0.4"
+  checksum: 10c0/6d67b9af4336a2e12b26a68c83308c7863534c65f27ed4ff7068a56f5a58f7ac703e8fc80f698a19bb154fd8f705cdf7ec347d9512b2c522c737269507e7b263
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Added comprehensive test coverage reporting to CI and fixed publish workflow issues.

- Integrated @vitest/coverage-v8 for code coverage measurement
- CI workflow now displays coverage summary table in job summary
- Fixed publish.yml to correctly check lzma-web package name
- Coverage reports available in text, JSON, HTML, and JSON-summary formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)