### PR TITLE
Update benchmark workflow to reuse single comment

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -111,12 +111,18 @@ jobs:
           script: |
             const fs = require('fs');
 
+            const COMMENT_MARKER = '<!-- lzma-benchmark-comment -->';
+
             let body;
             if (fs.existsSync('benchmark-comparison.md')) {
               body = fs.readFileSync('benchmark-comparison.md', 'utf8');
             } else {
               body = '⚠️ Benchmark comparison could not be generated. This may be expected if the main branch has a different structure.';
             }
+
+            // Add marker and timestamp
+            const timestamp = new Date().toISOString();
+            body = `${COMMENT_MARKER}\n${body}\n\n<sub>Last updated: ${timestamp}</sub>`;
 
             // Find existing benchmark comment
             const { data: comments } = await github.rest.issues.listComments({
@@ -127,7 +133,7 @@ jobs:
 
             const benchmarkComment = comments.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('📊 Benchmark Comparison')
+              comment.body.includes(COMMENT_MARKER)
             );
 
             if (benchmarkComment) {


### PR DESCRIPTION
## Summary
- Use a hidden HTML comment marker to reliably identify benchmark comments
- Update existing comment instead of creating duplicates on each workflow run
- Add timestamp showing when the benchmark was last updated

## Test plan
- [ ] Trigger the benchmark workflow and verify it creates a single comment
- [ ] Re-run the workflow and verify it updates the existing comment instead of creating a new one