### PR TITLE
Fix npm publish for prerelease versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       version-changed: ${{ steps.check.outputs.changed }}
       version: ${{ steps.check.outputs.version }}
       should-publish: ${{ steps.check.outputs.should_publish }}
+      prerelease: ${{ steps.check.outputs.prerelease }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,6 +40,14 @@ jobs:
           # Get published version from npm (if it exists)
           PUBLISHED_VERSION=$(npm view lzma-web version 2>/dev/null || echo "none")
           echo "Published version on npm: $PUBLISHED_VERSION"
+
+          # Check if this is a prerelease version (contains a hyphen, e.g. 4.0.0-rc.1)
+          if [[ "$CURRENT_VERSION" == *-* ]]; then
+            echo "Detected prerelease version"
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
 
           # Compare versions
           if [ "$PUBLISHED_VERSION" = "none" ]; then
@@ -96,7 +105,12 @@ jobs:
         run: yarn build
 
       - name: Publish to npm with provenance
-        run: npm publish --provenance --access public
+        run: |
+          if [ "${{ needs.check-version.outputs.prerelease }}" = "true" ]; then
+            npm publish --provenance --access public --tag next
+          else
+            npm publish --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -106,5 +120,5 @@ jobs:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}
           draft: false
-          prerelease: false
+          prerelease: ${{ needs.check-version.outputs.prerelease == 'true' }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- Fixes the publish workflow failing with `You must specify a tag using --tag when publishing a prerelease version` ([failed run](https://github.com/biw/lzma-web/actions/runs/23671048503/job/68964422921))
- Detects prerelease versions (e.g. `4.0.0-rc.1`) and publishes with `--tag next` instead of defaulting to `latest`
- Marks GitHub releases as prereleases when the version is a prerelease