### PR TITLE
[codex] Migrate pnpm configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,12 +108,5 @@
     "compression",
     "decompression"
   ],
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "lzma-native",
-      "msw"
-    ]
-  },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.5.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  lzma-native: true
+  msw: true


### PR DESCRIPTION
## Summary
- Moves pnpm build-script approvals into `pnpm-workspace.yaml` with `allowBuilds`.
- Updates the package manager pin to `pnpm@11.5.2`.

## Validation
- `CI=true corepack pnpm install --frozen-lockfile`
- `corepack pnpm lint`
- `corepack pnpm type-check`
- `corepack pnpm test`
- `corepack pnpm build`
