### PR TITLE
v4.0.0 release

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -381,6 +381,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download comparison reports
         uses: actions/download-artifact@v4
         continue-on-error: true

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BENCHMARK_GROUP: ${{ matrix.benchmark_group }}
+      COMPRESSION_RATIO_OUTPUT: compression-ratio-result.json
     strategy:
       fail-fast: false
       max-parallel: 30
@@ -95,10 +96,42 @@ jobs:
             label: Compress binary data at every mode
             file: tests/compression.bench.ts
             benchmark_group: 'compress:binary'
-          - id: compress-timeseries
-            label: Compress time-series text at every mode
+          - id: compress-timeseries-mode-1
+            label: Compress time-series text (mode 1)
             file: tests/compression.bench.ts
-            benchmark_group: 'compress:timeseries.txt'
+            benchmark_group: 'compress:timeseries.txt:mode:1'
+          - id: compress-timeseries-mode-2
+            label: Compress time-series text (mode 2)
+            file: tests/compression.bench.ts
+            benchmark_group: 'compress:timeseries.txt:mode:2'
+          - id: compress-timeseries-mode-3
+            label: Compress time-series text (mode 3)
+            file: tests/compression.bench.ts
+            benchmark_group: 'compress:timeseries.txt:mode:3'
+          - id: compress-timeseries-mode-4
+            label: Compress time-series text (mode 4)
+            file: tests/compression.bench.ts
+            benchmark_group: 'compress:timeseries.txt:mode:4'
+          - id: compress-timeseries-mode-5
+            label: Compress time-series text (mode 5)
+            file: tests/compression.bench.ts
+            benchmark_group: 'compress:timeseries.txt:mode:5'
+          - id: compress-timeseries-mode-6
+            label: Compress time-series text (mode 6)
+            file: tests/compression.bench.ts
+            benchmark_group: 'compress:timeseries.txt:mode:6'
+          - id: compress-timeseries-mode-7
+            label: Compress time-series text (mode 7)
+            file: tests/compression.bench.ts
+            benchmark_group: 'compress:timeseries.txt:mode:7'
+          - id: compress-timeseries-mode-8
+            label: Compress time-series text (mode 8)
+            file: tests/compression.bench.ts
+            benchmark_group: 'compress:timeseries.txt:mode:8'
+          - id: compress-timeseries-mode-9
+            label: Compress time-series text (mode 9)
+            file: tests/compression.bench.ts
+            benchmark_group: 'compress:timeseries.txt:mode:9'
           - id: execution-small-compression
             label: Execution modes for small-text compression
             file: tests/comparison.bench.ts
@@ -135,10 +168,18 @@ jobs:
             label: Libraries for binary compression
             file: tests/comparison.bench.ts
             benchmark_group: 'comparison:libraries-binary-compression'
-          - id: compression-ratio
-            label: Compression-ratio report
+          - id: compression-ratio-mode-1
+            label: Compression ratio (mode 1)
             file: tests/comparison.bench.ts
-            benchmark_group: 'comparison:compression-ratio'
+            benchmark_group: 'comparison:compression-ratio:mode:1'
+          - id: compression-ratio-mode-5
+            label: Compression ratio (mode 5)
+            file: tests/comparison.bench.ts
+            benchmark_group: 'comparison:compression-ratio:mode:5'
+          - id: compression-ratio-mode-9
+            label: Compression ratio (mode 9)
+            file: tests/comparison.bench.ts
+            benchmark_group: 'comparison:compression-ratio:mode:9'
 
     steps:
       - name: Checkout PR
@@ -166,12 +207,17 @@ jobs:
         run: pnpm generate
 
       - name: Run benchmarks on PR branch
-        run: pnpm test:bench "${{ matrix.file }}" || true
+        run: |
+          rm -f bench-results.json compression-ratio-result.json
+          pnpm test:bench "${{ matrix.file }}" || true
 
       - name: Save PR benchmark results
         run: |
           if [ -f bench-results.json ]; then
             cp bench-results.json /tmp/pr-results.json
+          fi
+          if [ -f compression-ratio-result.json ]; then
+            cp compression-ratio-result.json /tmp/pr-compression-ratio.json
           fi
 
       - name: Save selected benchmark harness
@@ -233,21 +279,30 @@ jobs:
         run: cp /tmp/selected-benchmark.bench.ts "${{ matrix.file }}"
 
       - name: Run benchmarks on main branch with pnpm
-        run: pnpm test:bench "${{ matrix.file }}" || true
+        run: |
+          rm -f bench-results.json compression-ratio-result.json
+          pnpm test:bench "${{ matrix.file }}" || true
         if: env.MAIN_PACKAGE_MANAGER == 'pnpm'
 
       - name: Run benchmarks on main branch with Yarn
         if: env.MAIN_PACKAGE_MANAGER == 'yarn'
-        run: corepack yarn test:bench "${{ matrix.file }}" || true
+        run: |
+          rm -f bench-results.json compression-ratio-result.json
+          corepack yarn test:bench "${{ matrix.file }}" || true
 
       - name: Run benchmarks on main branch with npm
         if: env.MAIN_PACKAGE_MANAGER == 'npm'
-        run: npm run test:bench -- "${{ matrix.file }}" || true
+        run: |
+          rm -f bench-results.json compression-ratio-result.json
+          npm run test:bench -- "${{ matrix.file }}" || true
 
       - name: Save main benchmark results
         run: |
           if [ -f bench-results.json ]; then
             cp bench-results.json /tmp/main-results.json
+          fi
+          if [ -f compression-ratio-result.json ]; then
+            cp compression-ratio-result.json /tmp/main-compression-ratio.json
           fi
 
       - name: Checkout PR branch again
@@ -263,6 +318,18 @@ jobs:
           fi
           if [ -f /tmp/main-results.json ]; then
             cp /tmp/main-results.json main-results.json
+          fi
+          if [ -f /tmp/pr-results.json ]; then
+            cp /tmp/pr-results.json "${{ matrix.id }}-pr-results.json"
+          fi
+          if [ -f /tmp/main-results.json ]; then
+            cp /tmp/main-results.json "${{ matrix.id }}-main-results.json"
+          fi
+          if [ -f /tmp/pr-compression-ratio.json ]; then
+            cp /tmp/pr-compression-ratio.json "${{ matrix.id }}-pr-compression-ratio.json"
+          fi
+          if [ -f /tmp/main-compression-ratio.json ]; then
+            cp /tmp/main-compression-ratio.json "${{ matrix.id }}-main-compression-ratio.json"
           fi
 
       - name: Generate comparison report
@@ -288,10 +355,23 @@ jobs:
 
       - name: Upload comparison report
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && !startsWith(matrix.id, 'compress-timeseries-mode-') && !startsWith(matrix.id, 'compression-ratio-mode-')
         with:
           name: benchmark-report-${{ matrix.id }}
           path: ${{ matrix.id }}-benchmark-comparison.md
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload split benchmark data
+        uses: actions/upload-artifact@v4
+        if: always() && (startsWith(matrix.id, 'compress-timeseries-mode-') || startsWith(matrix.id, 'compression-ratio-mode-'))
+        with:
+          name: benchmark-data-${{ matrix.id }}
+          path: |
+            ${{ matrix.id }}-pr-results.json
+            ${{ matrix.id }}-main-results.json
+            ${{ matrix.id }}-pr-compression-ratio.json
+            ${{ matrix.id }}-main-compression-ratio.json
           if-no-files-found: warn
           retention-days: 7
 
@@ -308,6 +388,17 @@ jobs:
           pattern: benchmark-report-*
           path: benchmark-reports
           merge-multiple: true
+
+      - name: Download split benchmark data
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: benchmark-data-*
+          path: benchmark-data
+          merge-multiple: true
+
+      - name: Merge split benchmark reports
+        run: node scripts/merge-split-benchmark-reports.js benchmark-data benchmark-reports
 
       - name: Combine comparison reports
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Chromium
-        run: pnpm exec playwright install --with-deps chromium
+        # GitHub's Ubuntu runner already provides the required system libraries.
+        # Avoid --with-deps here: it invokes apt and can block on runner locks.
+        run: pnpm exec playwright install chromium
 
       - name: Run browser Worker tests with coverage
         run: pnpm test:browser:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Test packaged consumer entry points
+        run: pnpm test:package
+
       - name: Check build output
         run: |
           if [ ! -f "dist/index.js" ] || [ ! -f "dist/index.cjs" ] || [ ! -f "dist/index.d.ts" ]; then
@@ -101,3 +104,39 @@ jobs:
 
       - name: Packaged Electron smoke test
         run: pnpm test:electron
+
+  browser-worker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.18.0
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "26"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run browser Worker tests with coverage
+        run: pnpm test:browser:coverage
+
+      - name: Publish browser coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-worker-coverage
+          path: coverage/browser
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,12 +127,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Chromium
-        # GitHub's Ubuntu runner already provides the required system libraries.
-        # Avoid --with-deps here: it invokes apt and can block on runner locks.
-        run: pnpm exec playwright install chromium
-
       - name: Run browser Worker tests with coverage
+        env:
+          PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH: /usr/bin/google-chrome
         run: pnpm test:browser:coverage
 
       - name: Publish browser coverage report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,9 +37,18 @@ jobs:
           echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "Current version in package.json: $CURRENT_VERSION"
 
-          # Get published version from npm (if it exists)
-          PUBLISHED_VERSION=$(npm view lzma-web version 2>/dev/null || echo "none")
-          echo "Published version on npm: $PUBLISHED_VERSION"
+          # Check the exact version, not just npm's latest dist-tag. A prerelease
+          # such as 4.0.0-rc.5 can already be published under the next dist-tag.
+          PUBLISHED_VERSION=$(npm view "lzma-web@$CURRENT_VERSION" version 2>/dev/null || true)
+
+          if [ -n "$PUBLISHED_VERSION" ]; then
+            echo "Exact version already published on npm: $PUBLISHED_VERSION"
+          else
+            # Ensure the registry is reachable before treating the exact version
+            # as unpublished. This command intentionally fails on a registry error.
+            LATEST_VERSION=$(npm view lzma-web version)
+            echo "Exact version is not published; current latest is $LATEST_VERSION"
+          fi
 
           # Check if this is a prerelease version (contains a hyphen, e.g. 4.0.0-rc.1)
           if [[ "$CURRENT_VERSION" == *-* ]]; then
@@ -49,17 +58,13 @@ jobs:
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 
-          # Compare versions
-          if [ "$PUBLISHED_VERSION" = "none" ]; then
-            echo "Package not yet published to npm"
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "should_publish=true" >> $GITHUB_OUTPUT
-          elif [ "$CURRENT_VERSION" = "$PUBLISHED_VERSION" ]; then
+          # Publish only versions that are not already immutable on npm.
+          if [ "$CURRENT_VERSION" = "$PUBLISHED_VERSION" ]; then
             echo "Version $CURRENT_VERSION is already published"
             echo "changed=false" >> $GITHUB_OUTPUT
             echo "should_publish=false" >> $GITHUB_OUTPUT
           else
-            echo "Version changed from $PUBLISHED_VERSION to $CURRENT_VERSION"
+            echo "Version $CURRENT_VERSION has not been published"
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "should_publish=true" >> $GITHUB_OUTPUT
           fi
@@ -92,14 +97,11 @@ jobs:
       - name: Generate modules
         run: pnpm generate
 
-      - name: Lint
-        run: pnpm lint
+      - name: Install Chromium for browser Worker tests
+        run: pnpm exec playwright install --with-deps chromium
 
-      - name: Test
-        run: pnpm test
-
-      - name: Build
-        run: pnpm build
+      - name: Run complete release gate
+        run: pnpm test:release
 
       - name: Ensure recent npm for trusted publishing
         run: npm install -g npm@latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,12 +97,9 @@ jobs:
       - name: Generate modules
         run: pnpm generate
 
-      - name: Install Chromium for browser Worker tests
-        # GitHub's Ubuntu runner already provides the required system libraries.
-        # Avoid --with-deps here: it invokes apt and can block on runner locks.
-        run: pnpm exec playwright install chromium
-
       - name: Run complete release gate
+        env:
+          PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH: /usr/bin/google-chrome
         run: pnpm test:release
 
       - name: Ensure recent npm for trusted publishing

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,9 @@ jobs:
         run: pnpm generate
 
       - name: Install Chromium for browser Worker tests
-        run: pnpm exec playwright install --with-deps chromium
+        # GitHub's Ubuntu runner already provides the required system libraries.
+        # Avoid --with-deps here: it invokes apt and can block on runner locks.
+        run: pnpm exec playwright install chromium
 
       - name: Run complete release gate
         run: pnpm test:release

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ bench-results.json
 main-results.json
 pr-results.json
 benchmark-comparison.md
+compression-ratio-result.json
 
 # pnpm
 .pnpm-store/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lzma-web",
   "description": "A JavaScript implementation of the Lempel-Ziv-Markov (LZMA) chain compression algorithm",
-  "version": "4.0.0-rc.5",
+  "version": "4.0.0",
   "homepage": "https://github.com/biw/lzma-web",
   "repository": {
     "type": "git",
@@ -11,6 +11,9 @@
     "url": "https://github.com/biw/lzma-web/issues"
   },
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -60,6 +63,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "devDependencies": {
     "@ark/attest": "^0.56.0",
     "@eslint/js": "^9.38.0",
@@ -96,8 +100,12 @@
     "test:perf": "node scripts/track-perf.js",
     "test:bench": "vitest bench",
     "test:compare": "vitest bench tests/comparison.bench.ts",
+    "pretest:browser": "pnpm build",
     "test:browser": "vitest run --config vitest.browser.config.ts",
-    "test:all": "vitest run && vitest run --config vitest.browser.config.ts",
+    "test:browser:coverage": "pnpm build && vitest run --config vitest.browser.config.ts --coverage",
+    "test:package": "pnpm build && node scripts/test-package-consumer.mjs",
+    "test:all": "pnpm test && pnpm test:package && pnpm test:browser",
+    "test:release": "pnpm lint && pnpm type-check && pnpm test:coverage && pnpm test:package && pnpm test:browser:coverage && pnpm test:electron",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "type-check": "tsc --noEmit",

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,7 @@
 
 [![CI][ci-badge]][ci]
 [![version][version-badge]][package]
-[![bundlephobia][bundlephobia-badge]][bundlephobia]
-[![MIT License][license-badge]][license]
+[![npm-downloads][npm-downloads-badge]][package]
 
 The fastest isomorphic LZMA compression library for JavaScript. Works in browsers, Electron, and Node.js with a tree-shakeable, Promise-based API and optional Web Worker support.
 
@@ -12,7 +11,7 @@ The fastest isomorphic LZMA compression library for JavaScript. Works in browser
 - **Multiple APIs** - Promise-based, synchronous, and Web Worker APIs
 - **Tree-shakeable** - Import only compression or decompression to reduce bundle size
 - **TypeScript** - Full type definitions included
-- **Web Workers** - Automatic off-main-thread compression in browsers
+- **Web Workers** - Optional, explicit off-main-thread compression in browsers
 - **Universal** - Works in browsers, Electron, and Node.js
 - **Electron-tested** - CI includes a packaged Electron smoke test with `asar`
 - **Compatible** - Output compatible with the reference LZMA implementation
@@ -30,6 +29,12 @@ yarn add lzma-web
 pnpm add lzma-web
 ```
 
+### Runtime Support
+
+For Node.js usage, lzma-web supports Node.js 18 and later. Release CI runs on
+Node.js 26; use the included `.nvmrc` for local development. The
+`lzma-web/worker` entry point additionally requires browser `Worker` support.
+
 ## Quick Start
 
 ```javascript
@@ -43,6 +48,29 @@ const decompressed = await decompress(compressed)
 
 console.log(decompressed) // 'Hello, World!'
 ```
+
+## Migrating from v3
+
+Version 4 replaces the default `LZMA` class with named functions. It also no
+longer creates a Web Worker automatically.
+
+```javascript
+// v3
+import LZMA from 'lzma-web'
+
+const lzma = new LZMA()
+const compressedV3 = await lzma.compress('Hello, World!', 9)
+
+// v4
+import { compress } from 'lzma-web'
+
+const compressedV4 = await compress('Hello, World!', 9)
+```
+
+To keep compression off the browser's main thread, use the explicit
+`lzma-web/worker` entry point and call `terminate()` when finished. The v3
+`.cb` callback API and internal `dist/*` imports are not supported in v4;
+use Promise APIs and the documented entry points below instead.
 
 ## API Reference
 
@@ -60,7 +88,9 @@ console.log(decompressed) // 'Hello, World!'
 
 ### Main API (`lzma-web`)
 
-The default entry point provides Promise-based compression and decompression.
+The default entry point provides Promise-based compression and decompression
+on the current thread. It does not create a Web Worker; use
+`lzma-web/worker` when keeping browser UI work off the main thread matters.
 
 ```javascript
 import { compress, decompress } from 'lzma-web'
@@ -141,25 +171,30 @@ const decompressed = decompressSync(compressed)
 
 ### Web Worker API (`lzma-web/worker`)
 
-Explicitly manage Web Worker lifecycle for browser applications.
+Use this browser-focused entry point to run compression and decompression in a
+Web Worker. It is created lazily on the first operation and must be terminated
+when no longer needed.
 
 ```javascript
 import { createWorkerLZMA } from 'lzma-web/worker'
 
-// Create a worker instance
+// Create a worker handle (the Worker is created on the first operation)
 const lzma = createWorkerLZMA()
 
-// Compress (runs in Web Worker)
-const compressed = await lzma.compress('Hello, World!', 9)
-
-// Decompress (runs in Web Worker)
-const decompressed = await lzma.decompress(compressed)
-
-// Clean up when done (important!)
-lzma.terminate()
+try {
+  // Both operations run in the Web Worker
+  const compressed = await lzma.compress('Hello, World!', 9)
+  const decompressed = await lzma.decompress(compressed)
+} finally {
+  // Clean up when done
+  lzma.terminate()
+}
 ```
 
-> **Note:** The Worker is created lazily on first operation. Call `terminate()` to clean up resources when you're done.
+> **Note:** This entry point rejects operations when Web Workers are
+> unavailable. Use `lzma-web` or `lzma-web/sync` in environments without
+> Worker support. The Worker is backed by a `blob:` URL, so sites with a
+> Content Security Policy must allow `blob:` worker sources.
 
 ---
 
@@ -170,10 +205,7 @@ For bundle size optimization, import only what you need.
 #### Compression Only (`lzma-web/compress`)
 
 ```javascript
-import { compress, compressSync, compressAsync } from 'lzma-web/compress'
-
-// Async compression (callback internally handled)
-const compressed = await compress('Hello, World!', 5)
+import { compressSync, compressAsync } from 'lzma-web/compress'
 
 // Sync compression (blocking)
 const compressedSync = compressSync('Hello, World!', 5)
@@ -184,13 +216,14 @@ const compressedWithProgress = await compressAsync('Hello, World!', 5, (p) => {
 })
 ```
 
+`lzma-web/compress` also exports the low-level `compress` function. Without a
+completion callback, it is synchronous; prefer `compressSync` or
+`compressAsync` for an explicit execution model.
+
 #### Decompression Only (`lzma-web/decompress`)
 
 ```javascript
-import { decompress, decompressSync, decompressAsync } from 'lzma-web/decompress'
-
-// Async decompression
-const decompressed = await decompress(compressedData)
+import { decompressSync, decompressAsync } from 'lzma-web/decompress'
 
 // Sync decompression (blocking)
 const decompressedSync = decompressSync(compressedData)
@@ -201,21 +234,27 @@ const decompressedWithProgress = await decompressAsync(compressedData, (p) => {
 })
 ```
 
+`lzma-web/decompress` also exports the low-level `decompress` function. Without
+a completion callback, it is synchronous; prefer `decompressSync` or
+`decompressAsync` for an explicit execution model.
+
 > **Tip:** Use these modules when you only need one operation. This significantly reduces bundle size through tree-shaking.
 
 ---
 
 ## Web Workers
 
-### How It Works
+### Choosing an Execution Model
 
-The main `lzma-web` API automatically uses Web Workers in browsers to prevent blocking the UI thread. Workers are initialized lazily on first use.
+- **`lzma-web`** — Promise-based work on the current thread. This is the
+  general-purpose API, but it does not create a Worker.
+- **`lzma-web/worker`** — Promise-based work in a Web Worker. Use this in a
+  browser when compression must not block UI work.
+- **`lzma-web/sync`** — Blocking, synchronous work. Use this only where
+  blocking is acceptable.
 
-### Fallback Behavior
-
-- **Browser with Web Workers:** Operations run in a background thread
-- **Browser without Web Workers:** Falls back to main thread (blocking)
-- **Node.js:** Runs in main thread (no Worker support)
+The worker entry point has no main-thread fallback: it rejects an operation if
+the environment does not provide `Worker` support.
 
 ### Manual Worker Management
 
@@ -224,7 +263,7 @@ Use `lzma-web/worker` when you need explicit control:
 ```javascript
 import { createWorkerLZMA } from 'lzma-web/worker'
 
-// Each call creates a new Worker
+// Each handle creates its own Worker lazily, on its first operation
 const worker1 = createWorkerLZMA()
 const worker2 = createWorkerLZMA()
 
@@ -248,17 +287,17 @@ Choose the right entry point for your use case:
 | Entry Point | Use Case | Bundle Impact |
 |-------------|----------|---------------|
 | `lzma-web` | Need both compress & decompress | Full library |
-| `lzma-web/compress` | Only compressing data | ~50% smaller |
-| `lzma-web/decompress` | Only decompressing data | ~50% smaller |
+| `lzma-web/compress` | Only compressing data | Excludes decompression code |
+| `lzma-web/decompress` | Only decompressing data | Excludes compression code |
 | `lzma-web/sync` | Synchronous operations only | Similar to main |
 
 Example for a client that only decompresses server-compressed data:
 
 ```javascript
-// Only imports decompression code - smaller bundle!
-import { decompress } from 'lzma-web/decompress'
+// Imports decompression code only; this runs asynchronously on the current thread
+import { decompressAsync } from 'lzma-web/decompress'
 
-const data = await decompress(serverResponse)
+const data = await decompressAsync(serverResponse)
 ```
 
 ---
@@ -290,11 +329,8 @@ pnpm test:bench
 
 ---
 
-[ci-badge]: https://img.shields.io/github/actions/workflow/status/biw/lzma-web/ci.yml?branch=main&style=flat-square
-[ci]: https://github.com/biw/lzma-web/actions/workflows/ci.yml
-[version-badge]: https://img.shields.io/npm/v/lzma-web.svg?style=flat-square
+[ci-badge]: https://badgen.net/github/checks/biw/lzma-web
+[ci]: https://github.com/biw/lzma-web/actions?query=branch%3Amain
+[version-badge]: https://badgen.net/npm/v/lzma-web
 [package]: https://www.npmjs.com/package/lzma-web
-[license-badge]: https://img.shields.io/npm/l/lzma-web.svg?style=flat-square
-[license]: https://github.com/biw/lzma-web/blob/main/LICENSE
-[bundlephobia]: https://bundlephobia.com/result?p=lzma-web
-[bundlephobia-badge]: https://img.shields.io/bundlephobia/minzip/lzma-web@latest?style=flat-square
+[npm-downloads-badge]: https://badgen.net/npm/dt/lzma-web

--- a/scripts/merge-split-benchmark-reports.js
+++ b/scripts/merge-split-benchmark-reports.js
@@ -185,6 +185,8 @@ function createRatioBody({ pairs, dataDirectory }) {
 
   let body = `Comparing **${ratioRows.length}** compression-ratio benchmarks between \`main\` and this PR.\n\n`
   body +=
+    '<details>\n<summary><strong>Compression-ratio changes</strong></summary>\n\n'
+  body +=
     '| Mode | Main compressed size | PR compressed size | Main ratio | PR ratio | Ratio change | Main time (ms) | PR time (ms) | Time change |\n'
   body +=
     '|------|----------------------|--------------------|------------|----------|--------------|----------------|--------------|-------------|\n'
@@ -194,7 +196,7 @@ function createRatioBody({ pairs, dataDirectory }) {
   }
 
   body +=
-    '\n*Ratios are deterministic and each mode is compressed once per revision. Compression-ratio change is measured in percentage points; lower is better.*\n'
+    '\n</details>\n\n*Ratios are deterministic and each mode is compressed once per revision. Compression-ratio change is measured in percentage points; lower is better.*\n'
   return body
 }
 

--- a/scripts/merge-split-benchmark-reports.js
+++ b/scripts/merge-split-benchmark-reports.js
@@ -194,7 +194,7 @@ function createRatioBody({ pairs, dataDirectory }) {
   }
 
   body +=
-    '\n*Compression-ratio change is measured in percentage points; lower is better.*\n'
+    '\n*Ratios are deterministic and each mode is compressed once per revision. Compression-ratio change is measured in percentage points; lower is better.*\n'
   return body
 }
 

--- a/scripts/merge-split-benchmark-reports.js
+++ b/scripts/merge-split-benchmark-reports.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+
+/**
+ * Rebuild consolidated PR benchmark reports from per-mode matrix artifacts.
+ *
+ * Long-running scenarios are split so their modes can run in parallel. Each
+ * mode still benchmarks the PR and main on the same runner; this script joins
+ * those independent result pairs back into the same PR-comment sections.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { compareResults, parseBenchmarkResults } from './compare-benchmarks.js'
+
+const performanceGroups = [
+  {
+    artifactPrefix: 'compress-timeseries',
+    title: 'Compress time-series text at every mode',
+    reportName: 'compress-timeseries-benchmark-comparison.md',
+  },
+]
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function modeFromFileName(fileName, artifactPrefix, suffix) {
+  const expression = new RegExp(
+    `^${artifactPrefix}-mode-(\\d+)-${suffix.replace('.', '\\.')}$`,
+  )
+  const match = fileName.match(expression)
+  return match ? Number(match[1]) : undefined
+}
+
+function filesFor(dataDirectory, artifactPrefix, suffix) {
+  if (!fs.existsSync(dataDirectory)) return []
+
+  return fs
+    .readdirSync(dataDirectory)
+    .map((fileName) => ({
+      fileName,
+      mode: modeFromFileName(fileName, artifactPrefix, suffix),
+    }))
+    .filter((entry) => entry.mode !== undefined)
+    .sort((left, right) => left.mode - right.mode)
+    .map(({ fileName, mode }) => ({
+      mode,
+      filePath: path.join(dataDirectory, fileName),
+    }))
+}
+
+function resultPairs(dataDirectory, artifactPrefix) {
+  const mainByMode = new Map(
+    filesFor(dataDirectory, artifactPrefix, 'main-results.json').map(
+      (entry) => [entry.mode, entry.filePath],
+    ),
+  )
+  const prByMode = new Map(
+    filesFor(dataDirectory, artifactPrefix, 'pr-results.json').map((entry) => [
+      entry.mode,
+      entry.filePath,
+    ]),
+  )
+
+  return [...new Set([...mainByMode.keys(), ...prByMode.keys()])]
+    .sort((left, right) => left - right)
+    .map((mode) => ({
+      mode,
+      mainPath: mainByMode.get(mode),
+      prPath: prByMode.get(mode),
+    }))
+}
+
+function mergedResults(paths) {
+  return {
+    files: paths.flatMap((filePath) => readJson(filePath).files || []),
+  }
+}
+
+function writeSectionReport({ pairs, title, reportPath, createBody }) {
+  const missingResult = pairs.find((pair) => !pair.mainPath || !pair.prPath)
+  if (missingResult) {
+    fs.writeFileSync(
+      reportPath,
+      `### 📊 ${title}\n\n⚠️ Missing benchmark results for mode ${missingResult.mode}.\n`,
+    )
+    return
+  }
+
+  if (pairs.length === 0) return
+
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'lzma-benchmark-merge-'),
+  )
+  const mainFile = path.join(temporaryDirectory, 'main-results.json')
+  const prFile = path.join(temporaryDirectory, 'pr-results.json')
+  const bodyFile = path.join(temporaryDirectory, 'benchmark-comparison.md')
+
+  try {
+    fs.writeFileSync(
+      mainFile,
+      JSON.stringify(mergedResults(pairs.map((pair) => pair.mainPath))),
+    )
+    fs.writeFileSync(
+      prFile,
+      JSON.stringify(mergedResults(pairs.map((pair) => pair.prPath))),
+    )
+
+    const body = createBody({ mainFile, prFile, bodyFile, pairs })
+    fs.writeFileSync(reportPath, `### 📊 ${title}\n\n${body}`)
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true })
+  }
+}
+
+function createPerformanceBody({ mainFile, prFile, bodyFile }) {
+  if (!compareResults({ mainFile, prFile, reportFile: bodyFile })) {
+    return '⚠️ Benchmark comparison could not be generated.\n'
+  }
+
+  return fs.readFileSync(bodyFile, 'utf8')
+}
+
+function singleBenchmarkMean(filePath) {
+  const benchmarks = parseBenchmarkResults(filePath)
+  if (!benchmarks || benchmarks.size !== 1) return undefined
+  return [...benchmarks.values()][0].mean
+}
+
+function formatPercent(value) {
+  return `${value.toFixed(4)}%`
+}
+
+function formatBytes(value) {
+  return `${(value / 1024).toFixed(1)} KiB`
+}
+
+function formatPercentagePointChange(mainValue, prValue) {
+  const difference = prValue - mainValue
+  const sign = difference >= 0 ? '+' : ''
+  return `${sign}${difference.toFixed(4)} pp`
+}
+
+function formatTimeChange(mainValue, prValue) {
+  const difference = ((prValue - mainValue) / mainValue) * 100
+  const sign = difference >= 0 ? '+' : ''
+  const formatted = `${sign}${difference.toFixed(2)}%`
+
+  if (Math.abs(difference) < 1) return formatted
+  return difference < 0 ? `🟢 ${formatted}` : `🔴 ${formatted}`
+}
+
+function ratioDataFor(dataDirectory, mode, branch) {
+  const filePath = path.join(
+    dataDirectory,
+    `compression-ratio-mode-${mode}-${branch}-compression-ratio.json`,
+  )
+  return fs.existsSync(filePath) ? readJson(filePath) : undefined
+}
+
+function createRatioBody({ pairs, dataDirectory }) {
+  const mainMeans = new Map(
+    pairs.map((pair) => [pair.mode, singleBenchmarkMean(pair.mainPath)]),
+  )
+  const prMeans = new Map(
+    pairs.map((pair) => [pair.mode, singleBenchmarkMean(pair.prPath)]),
+  )
+
+  const ratioRows = pairs.map((pair) => ({
+    mode: pair.mode,
+    main: ratioDataFor(dataDirectory, pair.mode, 'main'),
+    pr: ratioDataFor(dataDirectory, pair.mode, 'pr'),
+    mainMean: mainMeans.get(pair.mode),
+    prMean: prMeans.get(pair.mode),
+  }))
+
+  const incomplete = ratioRows.find(
+    ({ main, pr, mainMean, prMean }) => !main || !pr || !mainMean || !prMean,
+  )
+  if (incomplete) {
+    return `⚠️ Compression-ratio data could not be generated for mode ${incomplete.mode}.\n`
+  }
+
+  let body = `Comparing **${ratioRows.length}** compression-ratio benchmarks between \`main\` and this PR.\n\n`
+  body +=
+    '| Mode | Main compressed size | PR compressed size | Main ratio | PR ratio | Ratio change | Main time (ms) | PR time (ms) | Time change |\n'
+  body +=
+    '|------|----------------------|--------------------|------------|----------|--------------|----------------|--------------|-------------|\n'
+
+  for (const { mode, main, pr, mainMean, prMean } of ratioRows) {
+    body += `| ${mode} | ${formatBytes(main.compressedBytes)} | ${formatBytes(pr.compressedBytes)} | ${formatPercent(main.ratioPercent)} | ${formatPercent(pr.ratioPercent)} | ${formatPercentagePointChange(main.ratioPercent, pr.ratioPercent)} | ${mainMean.toFixed(2)} | ${prMean.toFixed(2)} | ${formatTimeChange(mainMean, prMean)} |\n`
+  }
+
+  body +=
+    '\n*Compression-ratio change is measured in percentage points; lower is better.*\n'
+  return body
+}
+
+export function mergeSplitBenchmarkReports({
+  dataDirectory,
+  reportsDirectory,
+}) {
+  fs.mkdirSync(reportsDirectory, { recursive: true })
+  const reports = []
+
+  for (const group of performanceGroups) {
+    const pairs = resultPairs(dataDirectory, group.artifactPrefix)
+    if (pairs.length === 0) continue
+
+    const reportPath = path.join(reportsDirectory, group.reportName)
+    writeSectionReport({
+      pairs,
+      title: group.title,
+      reportPath,
+      createBody: createPerformanceBody,
+    })
+    reports.push(reportPath)
+  }
+
+  const ratioPairs = resultPairs(dataDirectory, 'compression-ratio')
+  if (ratioPairs.length > 0) {
+    const reportPath = path.join(
+      reportsDirectory,
+      'compression-ratio-benchmark-comparison.md',
+    )
+    writeSectionReport({
+      pairs: ratioPairs,
+      title: 'Compression-ratio report',
+      reportPath,
+      createBody: ({ pairs }) => createRatioBody({ pairs, dataDirectory }),
+    })
+    reports.push(reportPath)
+  }
+
+  return reports
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [
+    dataDirectory = 'benchmark-data',
+    reportsDirectory = 'benchmark-reports',
+  ] = process.argv.slice(2)
+  const reports = mergeSplitBenchmarkReports({
+    dataDirectory,
+    reportsDirectory,
+  })
+  console.log(`Generated ${reports.length} consolidated benchmark report(s).`)
+}

--- a/scripts/test-electron-packaged.mjs
+++ b/scripts/test-electron-packaged.mjs
@@ -12,6 +12,7 @@ import {
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import * as esbuild from 'esbuild'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -111,6 +112,18 @@ try {
     ],
     appDir,
   )
+
+  // Bundle a real renderer consumer after installing the packed tarball. This
+  // resolves lzma-web/worker exactly as an Electron renderer bundler would.
+  await esbuild.build({
+    entryPoints: [path.join(appDir, 'renderer-entry.mjs')],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    outfile: path.join(appDir, 'renderer.js'),
+    logLevel: 'silent',
+  })
 
   run(
     electronPackagerCmd,

--- a/scripts/test-package-consumer.mjs
+++ b/scripts/test-package-consumer.mjs
@@ -1,0 +1,251 @@
+import { execFileSync } from 'node:child_process'
+import assert from 'node:assert/strict'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as esbuild from 'esbuild'
+
+const repositoryRoot = process.cwd()
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const tempDirectory = mkdtempSync(join(tmpdir(), 'lzma-web-package-consumer-'))
+const consumerDirectory = join(tempDirectory, 'consumer')
+const packDirectory = join(tempDirectory, 'pack')
+
+mkdirSync(consumerDirectory)
+mkdirSync(packDirectory)
+
+function run(command, args, cwd) {
+  return execFileSync(command, args, { cwd, encoding: 'utf8' })
+}
+
+function parseJsonArray(output) {
+  // npm 8 prints lifecycle output before --json output. The package test must
+  // support the minimum Node/npm environment we document, while still parsing
+  // npm's trailing JSON array on newer versions.
+  const match = output.match(/(?:^|\n)(\[[\s\S]*\])\s*$/)
+  if (!match) {
+    throw new Error(`npm did not return a JSON array:\n${output}`)
+  }
+  return JSON.parse(match[1])
+}
+
+function runNode(args) {
+  execFileSync(process.execPath, args, {
+    cwd: consumerDirectory,
+    stdio: 'inherit',
+  })
+}
+
+async function bundleConsumer(source) {
+  const result = await esbuild.build({
+    stdin: {
+      contents: source,
+      resolveDir: consumerDirectory,
+      sourcefile: 'consumer-entry.js',
+    },
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    minify: true,
+    treeShaking: true,
+    write: false,
+    logLevel: 'silent',
+  })
+
+  return result.outputFiles[0].contents.byteLength
+}
+
+try {
+  const packed = parseJsonArray(
+    run(
+      npm,
+      ['pack', '--json', '--ignore-scripts', '--pack-destination', packDirectory],
+      repositoryRoot,
+    ),
+  )
+  const tarball = packed[0]?.filename
+
+  if (!tarball || !readdirSync(packDirectory).includes(tarball)) {
+    throw new Error('npm pack did not create a tarball')
+  }
+
+  writeFileSync(
+    join(consumerDirectory, 'package.json'),
+    JSON.stringify({ name: 'lzma-web-package-consumer', private: true, type: 'module' }),
+  )
+  run(
+    npm,
+    [
+      'install',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--no-package-lock',
+      '--no-save',
+      join(packDirectory, tarball),
+    ],
+    consumerDirectory,
+  )
+
+  runNode([
+    '--input-type=module',
+    '--eval',
+    `
+      import assert from 'node:assert/strict'
+      import { compress, decompress } from 'lzma-web'
+      import { compressSync, decompressSync } from 'lzma-web/sync'
+      import { compress as compressOnly, compressAsync, compressSync as compressOnlySync } from 'lzma-web/compress'
+      import { decompress as decompressOnly, decompressAsync, decompressSync as decompressOnlySync } from 'lzma-web/decompress'
+      import { createWorkerLZMA } from 'lzma-web/worker'
+
+      const input = 'ESM consumer from an npm tarball: 🌍'
+      const rootCompressed = await compress(input, 1)
+      assert.equal(await decompress(rootCompressed), input)
+
+      const syncCompressed = compressSync(input, 1)
+      assert.equal(decompressSync(syncCompressed), input)
+
+      const rawCompressed = compressOnly(input, 1)
+      assert(rawCompressed instanceof Uint8Array)
+      assert(compressOnlySync(input, 1) instanceof Uint8Array)
+      assert(await compressAsync(input, 1) instanceof Uint8Array)
+
+      assert.equal(decompressOnly(syncCompressed), input)
+      assert.equal(decompressOnlySync(syncCompressed), input)
+      assert.equal(await decompressAsync(syncCompressed), input)
+
+      const worker = createWorkerLZMA()
+      assert.equal(worker.worker, null)
+    `,
+  ])
+
+  runNode([
+    '--input-type=commonjs',
+    '--eval',
+    `
+      const assert = require('node:assert/strict')
+      const main = require('lzma-web')
+      const sync = require('lzma-web/sync')
+      const compressOnly = require('lzma-web/compress')
+      const decompressOnly = require('lzma-web/decompress')
+      const workerApi = require('lzma-web/worker')
+
+      ;(async () => {
+        const input = 'CommonJS consumer from an npm tarball: 🌍'
+        const rootCompressed = await main.compress(input, 1)
+        assert.equal(await main.decompress(rootCompressed), input)
+
+        const syncCompressed = sync.compressSync(input, 1)
+        assert.equal(sync.decompressSync(syncCompressed), input)
+
+        assert(compressOnly.compress(input, 1) instanceof Uint8Array)
+        assert(compressOnly.compressSync(input, 1) instanceof Uint8Array)
+        assert(await compressOnly.compressAsync(input, 1) instanceof Uint8Array)
+
+        assert.equal(decompressOnly.decompress(syncCompressed), input)
+        assert.equal(decompressOnly.decompressSync(syncCompressed), input)
+        assert.equal(await decompressOnly.decompressAsync(syncCompressed), input)
+
+        assert.equal(typeof workerApi.createWorkerLZMA, 'function')
+      })().catch((error) => {
+        console.error(error)
+        process.exitCode = 1
+      })
+    `,
+  ])
+
+  writeFileSync(
+    join(consumerDirectory, 'consumer.mts'),
+    `
+      import { compress, decompress } from 'lzma-web'
+      import { compressSync, decompressSync } from 'lzma-web/sync'
+      import { compress as compressOnly, compressAsync, compressSync as compressOnlySync } from 'lzma-web/compress'
+      import { decompress as decompressOnly, decompressAsync, decompressSync as decompressOnlySync } from 'lzma-web/decompress'
+      import { createWorkerLZMA, type WorkerLZMA } from 'lzma-web/worker'
+
+      const input = 'TypeScript consumer'
+      const mainCompressed: Promise<Uint8Array> = compress(input, 1)
+      const mainDecompressed: Promise<string | Uint8Array> = decompress(await mainCompressed)
+      const syncCompressed: Uint8Array = compressSync(input, 1)
+      const syncDecompressed: string | Uint8Array = decompressSync(syncCompressed)
+      const rawCompressed: Uint8Array = compressOnly(input, 1)
+      const compressed: Promise<Uint8Array> = compressAsync(input, 1)
+      const compressionSync: Uint8Array = compressOnlySync(input, 1)
+      const rawDecompressed: string | Uint8Array = decompressOnly(rawCompressed)
+      const decompressed: Promise<string | Uint8Array> = decompressAsync(rawCompressed)
+      const decompressionSync: string | Uint8Array = decompressOnlySync(rawCompressed)
+      const worker: WorkerLZMA = createWorkerLZMA()
+
+      void [mainDecompressed, syncDecompressed, compressed, compressionSync, rawDecompressed, decompressed, decompressionSync, worker]
+    `,
+  )
+  runNode([
+    join(repositoryRoot, 'node_modules', 'typescript', 'bin', 'tsc'),
+    '--noEmit',
+    '--strict',
+    '--target',
+    'ES2020',
+    '--module',
+    'NodeNext',
+    '--moduleResolution',
+    'NodeNext',
+    'consumer.mts',
+  ])
+
+  const unusedImport = await bundleConsumer(
+    "import { compress } from 'lzma-web/compress'; console.log('tree-shaken')",
+  )
+  const rootCompress = await bundleConsumer(
+    "import { compress } from 'lzma-web'; console.log(compress)",
+  )
+  const rootBoth = await bundleConsumer(
+    "import { compress, decompress } from 'lzma-web'; console.log(compress, decompress)",
+  )
+  const syncCompress = await bundleConsumer(
+    "import { compressSync } from 'lzma-web/sync'; console.log(compressSync)",
+  )
+  const compressOnly = await bundleConsumer(
+    "import { compress } from 'lzma-web/compress'; console.log(compress)",
+  )
+  const decompressOnly = await bundleConsumer(
+    "import { decompress } from 'lzma-web/decompress'; console.log(decompress)",
+  )
+  const worker = await bundleConsumer(
+    "import { createWorkerLZMA } from 'lzma-web/worker'; console.log(createWorkerLZMA)",
+  )
+
+  assert.ok(
+    unusedImport < 100,
+    `unused imports should be removed entirely; bundled ${unusedImport} bytes`,
+  )
+  assert.ok(
+    rootBoth - rootCompress >= 4_000,
+    `root named imports should remove decompression code; saved ${rootBoth - rootCompress} bytes`,
+  )
+  assert.ok(
+    compressOnly <= rootCompress + 1_024,
+    `compression-only entry point should not exceed the root compression bundle (${compressOnly} bytes)`,
+  )
+  assert.ok(
+    decompressOnly < compressOnly * 0.6,
+    `decompression-only entry point should exclude compression code (${decompressOnly} bytes)`,
+  )
+  assert.ok(
+    syncCompress <= rootBoth - 4_000,
+    `sync entry point should not include the full default API (${syncCompress} bytes)`,
+  )
+  assert.ok(
+    worker > syncCompress,
+    'worker entry point should retain its self-contained Worker payload',
+  )
+
+  console.log('Package consumer and tree-shaking tests passed')
+} finally {
+  rmSync(tempDirectory, { recursive: true, force: true })
+}

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -6,10 +6,10 @@
  *
  * @example
  * ```ts
- * import { compress, compressSync } from 'lzma-web/compress'
+ * import { compressAsync, compressSync } from 'lzma-web/compress'
  *
  * // Async compression
- * const compressed = await compress('Hello, World!', 9)
+ * const compressed = await compressAsync('Hello, World!', 9)
  *
  * // Sync compression
  * const compressedSync = compressSync('Hello, World!', 1)

--- a/src/decompress.ts
+++ b/src/decompress.ts
@@ -6,10 +6,10 @@
  *
  * @example
  * ```ts
- * import { decompress, decompressSync } from 'lzma-web/decompress'
+ * import { decompressAsync, decompressSync } from 'lzma-web/decompress'
  *
  * // Async decompression
- * const decompressed = await decompress(compressedData)
+ * const decompressed = await decompressAsync(compressedData)
  *
  * // Sync decompression
  * const decompressedSync = decompressSync(compressedData)

--- a/src/lzma_main.ts
+++ b/src/lzma_main.ts
@@ -3553,6 +3553,16 @@ function encode(s: any): any {
 export function compress(
   str: string | Uint8Array | ArrayBuffer,
   mode: CompressMode,
+): Uint8Array
+export function compress(
+  str: string | Uint8Array | ArrayBuffer,
+  mode: CompressMode,
+  on_finish: OnFinishCallback | number,
+  on_progress?: OnProgressCallback,
+): void
+export function compress(
+  str: string | Uint8Array | ArrayBuffer,
+  mode: CompressMode,
   on_finish?: OnFinishCallback | number,
   on_progress?: OnProgressCallback,
 ): Uint8Array | void {
@@ -3655,6 +3665,14 @@ export function compress(
 }
 /** ce */
 /** ds */
+export function decompress(
+  byte_arr: Uint8Array | ArrayBuffer,
+): string | Uint8Array
+export function decompress(
+  byte_arr: Uint8Array | ArrayBuffer,
+  on_finish: OnFinishCallback | number,
+  on_progress?: OnProgressCallback,
+): void
 export function decompress(
   byte_arr: Uint8Array | ArrayBuffer,
   on_finish?: OnFinishCallback | number,

--- a/src/worker-api.ts
+++ b/src/worker-api.ts
@@ -55,6 +55,25 @@ export function createWorkerLZMA(): WorkerLZMA {
   let callbackId = 0
   const pendingCallbacks: Map<number, PendingCallback> = new Map()
 
+  function rejectPendingCallbacks(error: Error): void {
+    for (const pending of pendingCallbacks.values()) {
+      pending.reject(error)
+    }
+    pendingCallbacks.clear()
+  }
+
+  function disposeWorker(): void {
+    const activeWorker = worker
+    worker = null
+
+    activeWorker?.terminate()
+
+    if (workerUrl) {
+      URL.revokeObjectURL(workerUrl)
+      workerUrl = null
+    }
+  }
+
   function getWorker(): Worker {
     if (worker) return worker
 
@@ -66,12 +85,22 @@ export function createWorkerLZMA(): WorkerLZMA {
       )
     }
 
-    workerUrl = URL.createObjectURL(
+    const nextWorkerUrl = URL.createObjectURL(
       new Blob([workerThreadSource], { type: 'text/javascript' }),
     )
-    worker = new Worker(workerUrl, { type: 'module' })
 
-    worker.onmessage = (e: MessageEvent<WorkerMessage>) => {
+    let nextWorker: Worker
+    try {
+      nextWorker = new Worker(nextWorkerUrl, { type: 'module' })
+    } catch (error) {
+      URL.revokeObjectURL(nextWorkerUrl)
+      throw error
+    }
+
+    workerUrl = nextWorkerUrl
+    worker = nextWorker
+
+    nextWorker.onmessage = (e: MessageEvent<WorkerMessage>) => {
       const { action, cbn, result, error } = e.data
       const pending = pendingCallbacks.get(cbn)
 
@@ -102,21 +131,24 @@ export function createWorkerLZMA(): WorkerLZMA {
       }
     }
 
-    worker.onerror = (event: ErrorEvent) => {
+    nextWorker.onerror = (event: ErrorEvent) => {
+      // A stale event from a worker that has already been replaced must not
+      // affect the current worker instance.
+      if (worker !== nextWorker) return
+
       const err = new Error(
         `Worker error: ${event.message} (${event.filename}:${event.lineno})`,
       )
 
-      // Reject all pending operations
-      for (const [cbn, pending] of pendingCallbacks) {
-        pending.reject(err)
-        pendingCallbacks.delete(cbn)
-      }
+      // A worker error is terminal for that instance. Reject every operation,
+      // dispose it, and allow the next request to create a fresh worker.
+      rejectPendingCallbacks(err)
+      disposeWorker()
 
       console.error('Uncaught error in LZMA worker', err)
     }
 
-    return worker
+    return nextWorker
   }
 
   return {
@@ -174,20 +206,8 @@ export function createWorkerLZMA(): WorkerLZMA {
     },
 
     terminate(): void {
-      if (worker) {
-        // Reject any pending operations
-        for (const [cbn, pending] of pendingCallbacks) {
-          pending.reject(new Error('Worker terminated'))
-          pendingCallbacks.delete(cbn)
-        }
-
-        worker.terminate()
-        worker = null
-        if (workerUrl) {
-          URL.revokeObjectURL(workerUrl)
-          workerUrl = null
-        }
-      }
+      rejectPendingCallbacks(new Error('Worker terminated'))
+      disposeWorker()
     },
 
     get worker(): Worker | null {

--- a/tests/browser-consumer.setup.ts
+++ b/tests/browser-consumer.setup.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const fixtureDirectory = join(
+  repositoryRoot,
+  'tests',
+  'fixtures',
+  'browser-consumer',
+)
+const fixtureNodeModules = join(fixtureDirectory, 'node_modules')
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
+function runNpm(args: string[], cwd: string): string {
+  return execFileSync(npm, args, { cwd, encoding: 'utf8' })
+}
+
+export default function setupBrowserConsumer() {
+  const packDirectory = mkdtempSync(join(tmpdir(), 'lzma-web-browser-consumer-'))
+
+  try {
+    const packed = JSON.parse(
+      runNpm(
+        ['pack', '--json', '--ignore-scripts', '--pack-destination', packDirectory],
+        repositoryRoot,
+      ),
+    ) as Array<{ filename: string }>
+    const tarball = packed[0]?.filename
+
+    if (!tarball || !readdirSync(packDirectory).includes(tarball)) {
+      throw new Error('npm pack did not create a tarball')
+    }
+
+    runNpm(
+      [
+        'install',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+        '--no-package-lock',
+        '--no-save',
+        join(packDirectory, tarball),
+      ],
+      fixtureDirectory,
+    )
+  } catch (error) {
+    rmSync(fixtureNodeModules, { recursive: true, force: true })
+    rmSync(packDirectory, { recursive: true, force: true })
+    throw error
+  }
+
+  return () => {
+    rmSync(fixtureNodeModules, { recursive: true, force: true })
+    rmSync(packDirectory, { recursive: true, force: true })
+  }
+}

--- a/tests/comparison.bench.ts
+++ b/tests/comparison.bench.ts
@@ -54,9 +54,40 @@ const LZMA_MODE = 1
 // Benchmark options
 const benchOptions = { time: 3000, iterations: 5 }
 const benchmarkGroup = process.env.BENCHMARK_GROUP
+const compressionRatioModes = [1, 5, 9] as const
+const compressionRatioOutput = process.env.COMPRESSION_RATIO_OUTPUT
+let compressionRatioWritten = false
 
 const shouldRunGroup = (group: string) =>
   !benchmarkGroup || benchmarkGroup === group
+
+const shouldRunCompressionRatioMode = (mode: number) =>
+  !benchmarkGroup ||
+  benchmarkGroup === 'comparison:compression-ratio' ||
+  benchmarkGroup === `comparison:compression-ratio:mode:${mode}`
+
+const writeCompressionRatio = (mode: number, compressed: Uint8Array) => {
+  if (!compressionRatioOutput || compressionRatioWritten) return
+
+  const originalBytes = Buffer.byteLength(largeText, 'utf-8')
+  const compressedBytes = compressed.length
+
+  fs.writeFileSync(
+    compressionRatioOutput,
+    `${JSON.stringify(
+      {
+        input: 'large-kjv.txt',
+        mode,
+        originalBytes,
+        compressedBytes,
+        ratioPercent: (compressedBytes / originalBytes) * 100,
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  compressionRatioWritten = true
+}
 
 // Check if Workers are available (browser environment)
 const hasWorkers = typeof Worker !== 'undefined'
@@ -614,33 +645,15 @@ describe.skipIf(!shouldRunGroup('comparison:libraries-binary-compression'))(
 // Compression Ratio Comparison
 // ============================================================================
 
-describe.skipIf(!shouldRunGroup('comparison:compression-ratio'))(
-  'LZMA Compression Ratio by Mode',
-  () => {
-    bench(
-      'Calculate compression ratios',
+describe('LZMA Compression Ratio by Mode', () => {
+  compressionRatioModes.forEach((mode) => {
+    bench.skipIf(!shouldRunCompressionRatioMode(mode))(
+      `Calculate compression ratio (mode ${mode})`,
       () => {
-        const originalSize = Buffer.byteLength(largeText, 'utf-8')
-
-        // lzma-web at different modes
-        const mode1 = compressSync(largeText, 1)
-        const mode5 = compressSync(largeText, 5)
-        const mode9 = compressSync(largeText, 9)
-
-        console.log(
-          `\nCompression Ratios for large-kjv.txt (${(originalSize / 1024).toFixed(0)} KB):`,
-        )
-        console.log(
-          `  Mode 1: ${((mode1.length / originalSize) * 100).toFixed(1)}% (${(mode1.length / 1024).toFixed(0)} KB)`,
-        )
-        console.log(
-          `  Mode 5: ${((mode5.length / originalSize) * 100).toFixed(1)}% (${(mode5.length / 1024).toFixed(0)} KB)`,
-        )
-        console.log(
-          `  Mode 9: ${((mode9.length / originalSize) * 100).toFixed(1)}% (${(mode9.length / 1024).toFixed(0)} KB)`,
-        )
+        const compressed = compressSync(largeText, mode)
+        writeCompressionRatio(mode, compressed)
       },
       { iterations: 1, time: 1000 },
     )
-  },
-)
+  })
+})

--- a/tests/comparison.bench.ts
+++ b/tests/comparison.bench.ts
@@ -56,6 +56,15 @@ const benchOptions = { time: 3000, iterations: 5 }
 const benchmarkGroup = process.env.BENCHMARK_GROUP
 const compressionRatioModes = [1, 5, 9] as const
 const compressionRatioOutput = process.env.COMPRESSION_RATIO_OUTPUT
+// Ratios are deterministic, while compression performance is measured by the
+// dedicated execution-mode benchmarks. Avoid Tinybench's default warm-up work
+// here so each ratio mode is compressed exactly once per revision.
+const compressionRatioBenchOptions = {
+  iterations: 1,
+  time: 0,
+  warmupIterations: 0,
+  warmupTime: 0,
+}
 let compressionRatioWritten = false
 
 const shouldRunGroup = (group: string) =>
@@ -653,7 +662,7 @@ describe('LZMA Compression Ratio by Mode', () => {
         const compressed = compressSync(largeText, mode)
         writeCompressionRatio(mode, compressed)
       },
-      { iterations: 1, time: 1000 },
+      compressionRatioBenchOptions,
     )
   })
 })

--- a/tests/compression.bench.ts
+++ b/tests/compression.bench.ts
@@ -13,7 +13,12 @@ const compressionModes = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
 const benchmarkGroup = process.env.BENCHMARK_GROUP
 
 const shouldRunGroup = (group: string) =>
-  !benchmarkGroup || benchmarkGroup === group
+  !benchmarkGroup ||
+  benchmarkGroup === group ||
+  benchmarkGroup === group.replace(/:mode:\d+$/, '')
+
+const compressionModeGroup = (fileName: string, mode: number) =>
+  `compress:${fileName}:mode:${mode}`
 
 // Helper to run compression benchmark
 const benchCompress = (
@@ -81,7 +86,7 @@ describe('Compression Performance - Various Modes', () => {
       // Exercise every public compression mode for each representative input.
       compressionModes.forEach((mode) => {
         benchCompress(
-          `compress:${fileName}`,
+          compressionModeGroup(fileName, mode),
           `compress ${fileName} (mode ${mode})`,
           data,
           mode,

--- a/tests/fixtures/browser-consumer/entry-points-consumer.test.mjs
+++ b/tests/fixtures/browser-consumer/entry-points-consumer.test.mjs
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { compress, decompress } from 'lzma-web'
+import { createWorkerLZMA } from 'lzma-web/worker'
+import { compressSync, decompressSync } from 'lzma-web/sync'
+import {
+  compress as compressOnly,
+  compressAsync,
+  compressSync as compressOnlySync,
+} from 'lzma-web/compress'
+import {
+  decompress as decompressOnly,
+  decompressAsync,
+  decompressSync as decompressOnlySync,
+} from 'lzma-web/decompress'
+
+describe('packed lzma-web consumer', () => {
+  let lzma
+
+  afterEach(() => {
+    lzma?.terminate()
+    lzma = undefined
+  })
+
+  test('loads the default Promise entry point from the tarball', async () => {
+    const input = 'Default entry point from an npm tarball: \ud83c\udf0d'
+    const compressed = await compress(input, 1)
+
+    expect(compressed).toBeInstanceOf(Uint8Array)
+    await expect(decompress(compressed)).resolves.toBe(input)
+  })
+
+  test('loads the published Worker entry point and round-trips data', async () => {
+    lzma = createWorkerLZMA()
+    expect(lzma.worker).toBeNull()
+
+    const input = 'Worker entry point from an npm tarball: \ud83c\udf0d'
+    const compressed = await lzma.compress(input, 9)
+
+    expect(lzma.worker).toBeInstanceOf(Worker)
+    expect(compressed).toBeInstanceOf(Uint8Array)
+    await expect(lzma.decompress(compressed)).resolves.toBe(input)
+  })
+
+  test('loads the published synchronous entry point', () => {
+    const input = 'Synchronous entry point from an npm tarball'
+    const compressed = compressSync(input, 1)
+
+    expect(compressed).toBeInstanceOf(Uint8Array)
+    expect(decompressSync(compressed)).toBe(input)
+  })
+
+  test('loads every compression-only export from the tarball', async () => {
+    const input = 'Compression-only entry point from an npm tarball'
+
+    expect(compressOnly(input, 1)).toBeInstanceOf(Uint8Array)
+    expect(compressOnlySync(input, 1)).toBeInstanceOf(Uint8Array)
+    await expect(compressAsync(input, 1)).resolves.toBeInstanceOf(Uint8Array)
+  })
+
+  test('loads every decompression-only export from the tarball', async () => {
+    const input = 'Decompression-only entry point from an npm tarball'
+    const compressed = compressSync(input, 1)
+
+    expect(decompressOnly(compressed)).toBe(input)
+    expect(decompressOnlySync(compressed)).toBe(input)
+    await expect(decompressAsync(compressed)).resolves.toBe(input)
+  })
+})

--- a/tests/fixtures/browser-consumer/package.json
+++ b/tests/fixtures/browser-consumer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lzma-web-browser-consumer-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/tests/fixtures/electron-smoke/main.mjs
+++ b/tests/fixtures/electron-smoke/main.mjs
@@ -1,5 +1,10 @@
-import { app } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { compress, decompress } from 'lzma-web'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 process.on('uncaughtException', (error) => {
   console.error('SMOKE_FAIL uncaughtException', error)
@@ -13,14 +18,68 @@ process.on('unhandledRejection', (error) => {
 
 app.disableHardwareAcceleration()
 
+function runRendererWorkerSmoke() {
+  return new Promise((resolve, reject) => {
+    const window = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    })
+    let finished = false
+
+    const finish = (error) => {
+      if (finished) return
+      finished = true
+      clearTimeout(timeout)
+
+      if (!window.isDestroyed()) {
+        window.destroy()
+      }
+
+      if (error) reject(error)
+      else resolve()
+    }
+
+    const timeout = setTimeout(() => {
+      finish(new Error('renderer Worker smoke test timed out'))
+    }, 30_000)
+
+    window.webContents.on('console-message', ({ message }) => {
+      if (message === 'RENDERER_SMOKE_OK') finish()
+      if (message.startsWith('RENDERER_SMOKE_FAIL ')) {
+        finish(new Error(message))
+      }
+    })
+
+    window.webContents.once(
+      'did-fail-load',
+      (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+        if (isMainFrame) {
+          finish(
+            new Error(
+              `renderer failed to load ${validatedURL} (${errorCode}: ${errorDescription})`,
+            ),
+          )
+        }
+      },
+    )
+
+    window.loadFile(path.join(__dirname, 'renderer.html')).catch(finish)
+  })
+}
+
 app.whenReady().then(async () => {
-  const input = 'electron packaged smoke test'
+  const input = 'electron main-process smoke test'
   const compressed = await compress(input, 1)
   const decompressed = await decompress(compressed)
 
   if (decompressed !== input) {
     throw new Error(`roundtrip failed: ${String(decompressed)}`)
   }
+
+  await runRendererWorkerSmoke()
 
   console.log('SMOKE_OK')
   app.exit(0)

--- a/tests/fixtures/electron-smoke/renderer-entry.mjs
+++ b/tests/fixtures/electron-smoke/renderer-entry.mjs
@@ -1,0 +1,25 @@
+import { createWorkerLZMA } from 'lzma-web/worker'
+
+async function run() {
+  const lzma = createWorkerLZMA()
+
+  try {
+    const input = 'electron renderer Worker smoke test'
+    const compressed = await lzma.compress(input, 1)
+    const decompressed = await lzma.decompress(compressed)
+
+    if (decompressed !== input) {
+      throw new Error(`roundtrip failed: ${String(decompressed)}`)
+    }
+  } finally {
+    lzma.terminate()
+  }
+}
+
+run().then(
+  () => console.log('RENDERER_SMOKE_OK'),
+  (error) => {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error)
+    console.error(`RENDERER_SMOKE_FAIL ${message}`)
+  },
+)

--- a/tests/fixtures/electron-smoke/renderer.html
+++ b/tests/fixtures/electron-smoke/renderer.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>lzma-web Electron renderer smoke test</title>
+  </head>
+  <body>
+    <script type="module" src="./renderer.js"></script>
+  </body>
+</html>

--- a/tests/merge-split-benchmark-reports.test.ts
+++ b/tests/merge-split-benchmark-reports.test.ts
@@ -1,0 +1,161 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { mergeSplitBenchmarkReports } from '../scripts/merge-split-benchmark-reports.js'
+
+const benchmarkResults = (name: string, mean: number) => ({
+  files: [
+    {
+      filepath: 'tests/compression.bench.ts',
+      groups: [
+        {
+          fullName: 'Compression Performance - Various Modes > timeseries.txt',
+          benchmarks: [{ name, hz: 1, mean }],
+        },
+      ],
+    },
+  ],
+})
+
+const ratioResults = (mode: number, mean: number) => ({
+  files: [
+    {
+      filepath: 'tests/comparison.bench.ts',
+      groups: [
+        {
+          fullName: 'LZMA Compression Ratio by Mode',
+          benchmarks: [
+            {
+              name: `Calculate compression ratio (mode ${mode})`,
+              hz: 1,
+              mean,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+describe('mergeSplitBenchmarkReports', () => {
+  it('combines per-mode timing and ratio artifacts into the PR report sections', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'lzma-benchmark-'))
+    const dataDirectory = path.join(directory, 'data')
+    const reportsDirectory = path.join(directory, 'reports')
+
+    try {
+      await mkdir(dataDirectory)
+
+      for (const mode of [1, 9]) {
+        await writeFile(
+          path.join(
+            dataDirectory,
+            `compress-timeseries-mode-${mode}-main-results.json`,
+          ),
+          JSON.stringify(
+            benchmarkResults(
+              `compress timeseries.txt (mode ${mode})`,
+              mode * 10,
+            ),
+          ),
+        )
+        await writeFile(
+          path.join(
+            dataDirectory,
+            `compress-timeseries-mode-${mode}-pr-results.json`,
+          ),
+          JSON.stringify(
+            benchmarkResults(
+              `compress timeseries.txt (mode ${mode})`,
+              mode * 20,
+            ),
+          ),
+        )
+      }
+
+      for (const mode of [1, 5, 9]) {
+        await writeFile(
+          path.join(
+            dataDirectory,
+            `compression-ratio-mode-${mode}-main-results.json`,
+          ),
+          JSON.stringify(ratioResults(mode, mode * 100)),
+        )
+        await writeFile(
+          path.join(
+            dataDirectory,
+            `compression-ratio-mode-${mode}-pr-results.json`,
+          ),
+          JSON.stringify(ratioResults(mode, mode * 110)),
+        )
+        await writeFile(
+          path.join(
+            dataDirectory,
+            `compression-ratio-mode-${mode}-main-compression-ratio.json`,
+          ),
+          JSON.stringify({
+            mode,
+            originalBytes: 10_000,
+            compressedBytes: mode * 100,
+            ratioPercent: mode,
+          }),
+        )
+        await writeFile(
+          path.join(
+            dataDirectory,
+            `compression-ratio-mode-${mode}-pr-compression-ratio.json`,
+          ),
+          JSON.stringify({
+            mode,
+            originalBytes: 10_000,
+            compressedBytes: mode * 110,
+            ratioPercent: mode * 1.1,
+          }),
+        )
+      }
+
+      const reports = mergeSplitBenchmarkReports({
+        dataDirectory,
+        reportsDirectory,
+      })
+
+      expect(reports).toHaveLength(2)
+
+      const timeSeriesReport = await readFile(
+        path.join(
+          reportsDirectory,
+          'compress-timeseries-benchmark-comparison.md',
+        ),
+        'utf8',
+      )
+      expect(timeSeriesReport).toContain(
+        '### 📊 Compress time-series text at every mode',
+      )
+      expect(timeSeriesReport).toContain('Comparing **2** benchmarks')
+      expect(timeSeriesReport).toContain('compress timeseries.txt (mode 1)')
+      expect(timeSeriesReport).toContain('compress timeseries.txt (mode 9)')
+
+      const ratioReport = await readFile(
+        path.join(
+          reportsDirectory,
+          'compression-ratio-benchmark-comparison.md',
+        ),
+        'utf8',
+      )
+      expect(ratioReport).toContain('### 📊 Compression-ratio report')
+      expect(ratioReport).toContain(
+        'Comparing **3** compression-ratio benchmarks',
+      )
+      expect(ratioReport).toContain(
+        '| 5 | 0.5 KiB | 0.5 KiB | 5.0000% | 5.5000% | +0.5000 pp |',
+      )
+      expect(ratioReport).toContain(
+        '*Compression-ratio change is measured in percentage points; lower is better.*',
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/merge-split-benchmark-reports.test.ts
+++ b/tests/merge-split-benchmark-reports.test.ts
@@ -152,7 +152,7 @@ describe('mergeSplitBenchmarkReports', () => {
         '| 5 | 0.5 KiB | 0.5 KiB | 5.0000% | 5.5000% | +0.5000 pp |',
       )
       expect(ratioReport).toContain(
-        '*Compression-ratio change is measured in percentage points; lower is better.*',
+        '*Ratios are deterministic and each mode is compressed once per revision. Compression-ratio change is measured in percentage points; lower is better.*',
       )
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/tests/merge-split-benchmark-reports.test.ts
+++ b/tests/merge-split-benchmark-reports.test.ts
@@ -148,6 +148,11 @@ describe('mergeSplitBenchmarkReports', () => {
       expect(ratioReport).toContain(
         'Comparing **3** compression-ratio benchmarks',
       )
+      expect(ratioReport).toContain('<details>')
+      expect(ratioReport).toContain(
+        '<summary><strong>Compression-ratio changes</strong></summary>',
+      )
+      expect(ratioReport).toContain('</details>')
       expect(ratioReport).toContain(
         '| 5 | 0.5 KiB | 0.5 KiB | 5.0000% | 5.5000% | +0.5000 pp |',
       )

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -95,6 +95,265 @@ describe('Worker API', () => {
         }),
       )
     })
+
+    test('recreates the Worker after an uncaught Worker error', async () => {
+      class RecoveringWorkerMock {
+        static instances: RecoveringWorkerMock[] = []
+        onmessage: Worker['onmessage'] = null
+        onerror: Worker['onerror'] = null
+        terminated = false
+
+        constructor(_url: URL | string, _options?: unknown) {
+          RecoveringWorkerMock.instances.push(this)
+        }
+
+        postMessage(message: { action: number; cbn: number }): void {
+          if (RecoveringWorkerMock.instances[0] === this) {
+            queueMicrotask(() => {
+              this.onerror?.({
+                message: 'mock worker crash',
+                filename: 'mock-worker.js',
+                lineno: 1,
+              } as ErrorEvent)
+            })
+            return
+          }
+
+          queueMicrotask(() => {
+            const handler = this.onmessage as
+              | ((event: MessageEvent) => void)
+              | null
+            handler?.({
+              data: {
+                action: message.action,
+                cbn: message.cbn,
+                result: new Uint8Array([1]),
+              },
+            } as MessageEvent)
+          })
+        }
+
+        addEventListener(): void {}
+
+        removeEventListener(): void {}
+
+        terminate(): void {
+          this.terminated = true
+        }
+      }
+
+      vi.stubGlobal('Worker', RecoveringWorkerMock as unknown as typeof Worker)
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const lzma = createWorkerLZMA()
+
+      await expect(lzma.compress('first request', 1)).rejects.toThrow(
+        /Worker error: mock worker crash/,
+      )
+      expect(lzma.worker).toBeNull()
+      expect(RecoveringWorkerMock.instances[0].terminated).toBe(true)
+
+      await expect(lzma.compress('recovered request', 1)).resolves.toEqual(
+        new Uint8Array([1]),
+      )
+      expect(RecoveringWorkerMock.instances).toHaveLength(2)
+      expect(lzma.worker).toBe(
+        RecoveringWorkerMock.instances[1] as unknown as Worker,
+      )
+    })
+
+    test('cleans up the Blob URL when Worker construction fails', async () => {
+      class ConstructionFailingWorkerMock {
+        constructor(_url: URL | string, _options?: unknown) {
+          throw new Error('mock Worker construction failure')
+        }
+      }
+
+      vi.stubGlobal(
+        'Worker',
+        ConstructionFailingWorkerMock as unknown as typeof Worker,
+      )
+      const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL')
+      const lzma = createWorkerLZMA()
+
+      await expect(lzma.compress('test', 1)).rejects.toThrow(
+        'mock Worker construction failure',
+      )
+      expect(lzma.worker).toBeNull()
+      expect(revokeObjectURL).toHaveBeenCalledTimes(1)
+    })
+
+    test('ignores errors emitted by an already-replaced Worker', async () => {
+      class WorkerMock {
+        static instances: WorkerMock[] = []
+        onmessage: Worker['onmessage'] = null
+        onerror: Worker['onerror'] = null
+
+        constructor(_url: URL | string, _options?: unknown) {
+          WorkerMock.instances.push(this)
+        }
+
+        postMessage(_message: unknown): void {}
+
+        addEventListener(): void {}
+
+        removeEventListener(): void {}
+
+        terminate(): void {}
+      }
+
+      vi.stubGlobal('Worker', WorkerMock as unknown as typeof Worker)
+      const lzma = createWorkerLZMA()
+      const firstOperation = lzma.compress('first request', 1)
+      const firstWorker = WorkerMock.instances[0]
+
+      lzma.terminate()
+      await expect(firstOperation).rejects.toThrow('Worker terminated')
+
+      const secondOperation = lzma.compress('second request', 1)
+      const secondWorker = WorkerMock.instances[1]
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      firstWorker.onerror?.({
+        message: 'stale worker crash',
+        filename: 'mock-worker.js',
+        lineno: 1,
+      } as ErrorEvent)
+
+      expect(lzma.worker).toBe(secondWorker as unknown as Worker)
+      expect(errorSpy).not.toHaveBeenCalled()
+
+      lzma.terminate()
+      await expect(secondOperation).rejects.toThrow('Worker terminated')
+    })
+
+    test('ignores a message with no pending operation', async () => {
+      class WorkerMock {
+        static instance: WorkerMock
+        onmessage: Worker['onmessage'] = null
+        onerror: Worker['onerror'] = null
+
+        constructor(_url: URL | string, _options?: unknown) {
+          WorkerMock.instance = this
+        }
+
+        postMessage(message: { action: number; cbn: number }): void {
+          const handler = this.onmessage as ((event: MessageEvent) => void) | null
+          handler?.({
+            data: {
+              action: message.action,
+              cbn: message.cbn,
+              result: new Uint8Array([1]),
+            },
+          } as MessageEvent)
+        }
+
+        addEventListener(): void {}
+
+        removeEventListener(): void {}
+
+        terminate(): void {}
+      }
+
+      vi.stubGlobal('Worker', WorkerMock as unknown as typeof Worker)
+      const lzma = createWorkerLZMA()
+      await lzma.compress('test', 1)
+
+      expect(() => {
+        const handler = WorkerMock.instance.onmessage as
+          | ((event: MessageEvent) => void)
+          | null
+        handler?.({
+          data: { action: 1, cbn: 0, result: new Uint8Array([1]) },
+        } as MessageEvent)
+      }).not.toThrow()
+    })
+
+    test('rejects worker errors and invalid completion messages', async () => {
+      class WorkerMock {
+        onmessage: Worker['onmessage'] = null
+        onerror: Worker['onerror'] = null
+
+        constructor(_url: URL | string, _options?: unknown) {}
+
+        postMessage(message: { action: number; cbn: number }): void {
+          const handler = this.onmessage as ((event: MessageEvent) => void) | null
+          handler?.({
+            data:
+              message.action === 1
+                ? { action: 1, cbn: message.cbn, error: 'worker failed' }
+                : { action: 2, cbn: message.cbn, result: 0 },
+          } as MessageEvent)
+        }
+
+        addEventListener(): void {}
+
+        removeEventListener(): void {}
+
+        terminate(): void {}
+      }
+
+      vi.stubGlobal('Worker', WorkerMock as unknown as typeof Worker)
+      const lzma = createWorkerLZMA()
+
+      await expect(lzma.compress('test', 1)).rejects.toThrow('worker failed')
+      await expect(lzma.decompress(new Uint8Array([1]))).rejects.toThrow(
+        'Operation failed: no result returned',
+      )
+    })
+
+    test('normalizes postMessage failures', async () => {
+      class ThrowingWorkerMock {
+        onmessage: Worker['onmessage'] = null
+        onerror: Worker['onerror'] = null
+
+        constructor(_url: URL | string, _options?: unknown) {}
+
+        postMessage(message: { action: number }): void {
+          if (message.action === 1) throw 'compression post failed'
+          throw new Error('decompression post failed')
+        }
+
+        addEventListener(): void {}
+
+        removeEventListener(): void {}
+
+        terminate(): void {}
+      }
+
+      vi.stubGlobal('Worker', ThrowingWorkerMock as unknown as typeof Worker)
+      const lzma = createWorkerLZMA()
+
+      await expect(lzma.compress('test', 1)).rejects.toThrow(
+        'compression post failed',
+      )
+      await expect(lzma.decompress(new Uint8Array([1]))).rejects.toThrow(
+        'decompression post failed',
+      )
+    })
+
+    test('rejects pending work when terminated', async () => {
+      class PendingWorkerMock {
+        onmessage: Worker['onmessage'] = null
+        onerror: Worker['onerror'] = null
+
+        constructor(_url: URL | string, _options?: unknown) {}
+
+        postMessage(_message: unknown): void {}
+
+        addEventListener(): void {}
+
+        removeEventListener(): void {}
+
+        terminate(): void {}
+      }
+
+      vi.stubGlobal('Worker', PendingWorkerMock as unknown as typeof Worker)
+      const lzma = createWorkerLZMA()
+      const operation = lzma.compress('test', 1)
+      lzma.terminate()
+
+      await expect(operation).rejects.toThrow('Worker terminated')
+    })
   })
 
   describe.skipIf(!hasWorker)('with real Workers', () => {

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from 'vitest/config'
 
+// GitHub-hosted Ubuntu runners already include Google Chrome.  Using it there
+// avoids a large, occasionally stalled Playwright browser download while
+// retaining Playwright-managed Chromium for local development.
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+
 export default defineConfig({
   optimizeDeps: {
     // Resolve this from the browser consumer fixture instead of pre-bundling
@@ -24,6 +29,13 @@ export default defineConfig({
       enabled: true,
       name: 'chromium',
       provider: 'playwright',
+      providerOptions: chromiumExecutablePath
+        ? {
+            launch: {
+              executablePath: chromiumExecutablePath,
+            },
+          }
+        : {},
       headless: true,
     },
     coverage: {

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,15 +1,43 @@
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  optimizeDeps: {
+    // Resolve this from the browser consumer fixture instead of pre-bundling
+    // the package self-reference from this repository.
+    exclude: [
+      'lzma-web',
+      'lzma-web/sync',
+      'lzma-web/worker',
+      'lzma-web/compress',
+      'lzma-web/decompress',
+    ],
+  },
   test: {
     testTimeout: 90 * 1000,
-    // Only run browser-specific tests (Worker tests)
-    include: ['tests/worker.test.ts'],
+    // Run Worker behavior tests and the packed browser consumer fixture.
+    include: [
+      'tests/worker.test.ts',
+      'tests/fixtures/browser-consumer/entry-points-consumer.test.mjs',
+    ],
+    globalSetup: ['tests/browser-consumer.setup.ts'],
     browser: {
       enabled: true,
       name: 'chromium',
       provider: 'playwright',
       headless: true,
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
+      reportsDirectory: './coverage/browser',
+      include: ['src/worker-api.ts'],
+      exclude: ['src/generated/**', 'src/worker-thread.ts'],
+      thresholds: {
+        statements: 95,
+        branches: 85,
+        functions: 100,
+        lines: 95,
+      },
     },
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,12 @@ export default defineConfig({
         'src/generated/**',
         'src/worker-thread.ts', // Worker entry point
       ],
+      thresholds: {
+        statements: 93,
+        branches: 91,
+        functions: 92,
+        lines: 93,
+      },
     },
   },
 })


### PR DESCRIPTION
Prepares lzma-web 4.0.0 with updated API and migration documentation plus a declared Node.js runtime contract.

Adds packed ESM, CommonJS, TypeScript, tree-shaking, Chromium Worker, and packaged Electron renderer Worker coverage across every public entry point, including Worker recovery regression tests.

Hardens publication by checking the exact npm version and requiring the full release validation suite before publishing.