### PR TITLE
Use reusable npm publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,11 @@ jobs:
           name: browser-worker-coverage
           path: coverage/browser
           if-no-files-found: warn
+
+  publish:
+    needs: [lint-and-build, electron-smoke, browser-worker]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: write
+      id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
 name: Publish to npm
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  workflow_call:
 
 permissions:
   contents: read
@@ -14,15 +12,10 @@ concurrency:
 
 jobs:
   check-version:
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}
-      should-publish: ${{ steps.check.outputs.should_publish }}
+      should_publish: ${{ steps.check.outputs.should_publish }}
       prerelease: ${{ steps.check.outputs.prerelease }}
 
     steps:
@@ -30,12 +23,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: Verify the tested revision is still main
         id: revision
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           if [ "$(git rev-parse HEAD)" != "$TESTED_SHA" ]; then
             echo "Checked out revision does not match the successful CI run" >&2
@@ -90,7 +83,7 @@ jobs:
 
   publish:
     needs: check-version
-    if: needs.check-version.outputs.should-publish == 'true'
+    if: needs.check-version.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -100,7 +93,7 @@ jobs:
       - name: Checkout the CI-tested revision
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -135,7 +128,7 @@ jobs:
 
       - name: Reconfirm the published revision
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           git fetch --no-tags origin main
 
@@ -158,7 +151,7 @@ jobs:
       - publish
     if: >-
       needs.check-version.result == 'success' &&
-      needs.check-version.outputs.should-publish == 'true' &&
+      needs.check-version.outputs.should_publish == 'true' &&
       needs.publish.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -170,7 +163,7 @@ jobs:
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}
-          target_commitish: ${{ github.event.workflow_run.head_sha }}
+          target_commitish: ${{ github.sha }}
           draft: false
           prerelease: ${{ needs.check-version.outputs.prerelease == 'true' }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary

- Convert publish.yml from a detached workflow_run workflow to a reusable workflow called by CI after its required jobs pass.
- Keeps prerelease publishing to the next tag and waits for all three CI jobs.
- Retain stale-main protection, serialized publishing, version detection, trusted publishing, and separate publish/release permissions.

## Required npm configuration

Before the first release after merge, update the package's npm Trusted Publisher workflow filename to ci.yml (the calling CI workflow), rather than publish.yml.